### PR TITLE
Fix: missing flag state when Stream was failed

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
         {
             get
             {
-                var INTL = Symbol.Create("INTL", SecurityType.Equity, Market.USA);
+                var INTL = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
                 yield return new TestCaseData(INTL, OrderType.Limit);
                 yield return new TestCaseData(INTL, OrderType.StopMarket);
                 yield return new TestCaseData(INTL, OrderType.StopLimit);
@@ -337,20 +337,26 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
 
             var order = OrderProvider.GetOrderById(1);
 
-            var newLastPrice = _brokerage.GetLastPrice(symbol);
-            var newLimitPrice = AddAndRound(newLastPrice, 0.4m);
-
-            order.ApplyUpdateOrderRequest(new UpdateOrderRequest(DateTime.UtcNow, order.Id, new() { LimitPrice = newLimitPrice }));
-
-            if (!Brokerage.UpdateOrder(order))
+            var subtractor = 0.1m;
+            var subtraction = 0.5m;
+            do
             {
-                Assert.Fail("Brokerage failed to update the order: " + order);
-            }
+                subtraction -= subtractor;
+                var newLastPrice = _brokerage.GetLastPrice(symbol);
+                var newLimitPrice = Math.Round(newLastPrice - subtraction, 2);
 
-            if (!updateSubmittedResetEvent.WaitOne(TimeSpan.FromSeconds(10)))
-            {
-                Assert.Fail($"{nameof(PlaceLimitOrderAndUpdate)}: the brokerage doesn't return {OrderStatus.UpdateSubmitted}");
-            }
+                order.ApplyUpdateOrderRequest(new UpdateOrderRequest(DateTime.UtcNow, order.Id, new() { LimitPrice = newLimitPrice }));
+
+                if (!Brokerage.UpdateOrder(order))
+                {
+                    Assert.Fail("Brokerage failed to update the order: " + order);
+                }
+
+                if (!updateSubmittedResetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                {
+                    Assert.Fail($"{nameof(PlaceLimitOrderAndUpdate)}: the brokerage doesn't return {OrderStatus.UpdateSubmitted}");
+                }
+            } while (subtraction != 0);
 
             if (!filledResetEvent.WaitOne(TimeSpan.FromSeconds(10)))
             {

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -338,7 +338,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             var order = OrderProvider.GetOrderById(1);
 
             var subtractor = 0.1m;
-            var subtraction = 0.5m;
+            var subtraction = 0.3m;
             do
             {
                 subtraction -= subtractor;
@@ -356,7 +356,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
                 {
                     Assert.Fail($"{nameof(PlaceLimitOrderAndUpdate)}: the brokerage doesn't return {OrderStatus.UpdateSubmitted}");
                 }
-            } while (subtraction != 0);
+            } while (subtraction > -subtractor);
 
             if (!filledResetEvent.WaitOne(TimeSpan.FromSeconds(10)))
             {
@@ -432,8 +432,8 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             return orderType switch
             {
                 OrderType.Limit => new LimitOrderTestParameters(symbol, AddAndRound(lastPrice, 0.2m), SubtractAndRound(lastPrice, 0.2m)),
-                OrderType.StopMarket => new StopMarketOrderTestParameters(symbol, AddAndRound(lastPrice, 0.2m), AddAndRound(lastPrice, 0.3m)),
-                OrderType.StopLimit => new StopLimitOrderTestParameters(symbol, AddAndRound(lastPrice, 0.2m), AddAndRound(lastPrice, 0.3m)),
+                OrderType.StopMarket => new StopMarketOrderTestParameters(symbol, AddAndRound(lastPrice, 0.4m), AddAndRound(lastPrice, 0.6m)),
+                OrderType.StopLimit => new StopLimitOrderTestParameters(symbol, AddAndRound(lastPrice, 0.4m), AddAndRound(lastPrice, 0.6m)),
                 _ => throw new NotImplementedException("Not supported type of order")
             };
         }

--- a/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
@@ -205,9 +205,15 @@ public class TokenRefreshHandler : DelegatingHandler
         {
             { "grant_type", "refresh_token" },
             { "client_id", _apiKey },
-            { "client_secret", _apiKeySecret},
             { "refresh_token", refreshToken }
         };
+
+        // The secret for the client application’s API Key. Required for standard Auth Code Flow. Not required for Auth Code Flow with PKCE.
+        // https://api.tradestation.com/docs/fundamentals/authentication/refresh-tokens
+        if (!string.IsNullOrEmpty(_apiKeySecret))
+        {
+            parameters["client_secret"] = _apiKeySecret;
+        }
 
         var response = await SendSignInAsync(new FormUrlEncodedContent(parameters), cancellationToken);
 

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -253,7 +253,7 @@ public class TradeStationApiClient
                     using (StreamReader reader = new StreamReader(stream))
                     {
                         Log.Trace($"{nameof(TradeStationApiClient)}.{nameof(StreamOrders)}: We are now starting to read the order stream.");
-                        while (!reader.EndOfStream)
+                        while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
                         {
                             var jsonLine = await reader.ReadLineAsync();
                             if (jsonLine == null) break;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -466,7 +466,7 @@ public class TradeStationBrokerage : Brokerage
     public override void Disconnect()
     {
         _cancellationTokenSource.Cancel();
-        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromSeconds(3)))
+        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromSeconds(5)))
         {
             Log.Error($"{nameof(TradeStationBrokerage)}.{nameof(Disconnect)}: TimeOut waiting for stream order task to end.");
         }
@@ -578,6 +578,8 @@ public class TradeStationBrokerage : Brokerage
                 case TradeStationOrderStatusType.Bro:
                     leanOrderStatus = OrderStatus.Invalid;
                     break;
+                // Sometimes, a Out event is received without the ClosedDateTime property set. 
+                // Subsequently, another event is received with the ClosedDateTime property correctly populated.
                 case TradeStationOrderStatusType.Out when brokerageOrder.ClosedDateTime != default:
                     // Remove the order entry if it was marked as submitted but is now out
                     // Sometimes, the order receives an "Out" status on every even occurrence

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -553,7 +553,9 @@ public class TradeStationBrokerage : Brokerage
             var leanOrderStatus = default(OrderStatus);
             switch (brokerageOrder.Status)
             {
-                case TradeStationOrderStatusType.Fll:
+                // Sometimes, a filled event is received without the ClosedDateTime property set. 
+                // Subsequently, another event is received with the ClosedDateTime property correctly populated.
+                case TradeStationOrderStatusType.Fll when brokerageOrder.ClosedDateTime != default:
                 case TradeStationOrderStatusType.Brf:
                     leanOrderStatus = OrderStatus.Filled;
                     break;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -520,6 +520,10 @@ public class TradeStationBrokerage : Brokerage
                 {
                     Log.Error($"{nameof(TradeStationBrokerage)}.{nameof(SubscribeOnOrderUpdate)}.Exception: {ex}");
                 }
+                finally
+                {
+                    _isSubscribeOnStreamOrderUpdate = false;
+                }
                 Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(SubscribeOnOrderUpdate)}: Connection lost. Reconnecting in 10 seconds...");
                 _cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
             }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -466,7 +466,7 @@ public class TradeStationBrokerage : Brokerage
     public override void Disconnect()
     {
         _cancellationTokenSource.Cancel();
-        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)))
+        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromMilliseconds(5000)))
         {
             Log.Error($"{nameof(TradeStationBrokerage)}.{nameof(Disconnect)}: TimeOut waiting for stream order task to end.");
         }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -578,7 +578,7 @@ public class TradeStationBrokerage : Brokerage
                 case TradeStationOrderStatusType.Bro:
                     leanOrderStatus = OrderStatus.Invalid;
                     break;
-                case TradeStationOrderStatusType.Out:
+                case TradeStationOrderStatusType.Out when brokerageOrder.ClosedDateTime != default:
                     // Remove the order entry if it was marked as submitted but is now out
                     // Sometimes, the order receives an "Out" status on every even occurrence
                     if (_updateSubmittedResponseResultByBrokerageID.TryRemove(new(brokerageOrder.OrderID, true)))

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -466,7 +466,7 @@ public class TradeStationBrokerage : Brokerage
     public override void Disconnect()
     {
         _cancellationTokenSource.Cancel();
-        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromMilliseconds(5000)))
+        if (!_orderUpdateEndManualResetEvent.WaitOne(TimeSpan.FromSeconds(3)))
         {
             Log.Error($"{nameof(TradeStationBrokerage)}.{nameof(Disconnect)}: TimeOut waiting for stream order task to end.");
         }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerageFactory.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerageFactory.cs
@@ -37,7 +37,9 @@ public class TradeStationBrokerageFactory : BrokerageFactory
     public override Dictionary<string, string> BrokerageData => new()
     {
         { "trade-station-api-key", Config.Get("trade-station-api-key") },
-        { "trade-station-api-secret", Config.Get("trade-station-api-secret") },
+        // Optional: The secret for the client application’s API Key. Required for standard Auth Code Flow. Not required for Auth Code Flow with PKCE.
+        // https://api.tradestation.com/docs/fundamentals/authentication/refresh-tokens
+        { "trade-station-api-secret", Config.Get("trade-station-api-secret", "") },
         // The URL to connect to brokerage environment:
         // Simulator(SIM): https://sim-api.tradestation.com/v3
         // LIVE: https://api.tradestation.com/v3

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerageFactory.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerageFactory.cs
@@ -79,7 +79,13 @@ public class TradeStationBrokerageFactory : BrokerageFactory
         var errors = new List<string>();
 
         var apiKey = Read<string>(job.BrokerageData, "trade-station-api-key", errors);
-        var apiSecret = Read<string>(job.BrokerageData, "trade-station-api-secret", errors);
+
+        var apiSecret = default(string);
+        if (job.BrokerageData.ContainsKey("trade-station-api-secret"))
+        {
+            apiSecret = Read<string>(job.BrokerageData, "trade-station-api-secret", errors);
+        }
+
         var apiUrl = Read<string>(job.BrokerageData, "trade-station-api-url", errors);
         var accountType = Read<string>(job.BrokerageData, "trade-station-account-type", errors);
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This pull request addresses an issue where the `boolean` flag `_isSubscribeOnStreamOrderUpdate` was not set to skip the snapshot of orders event when an exception occurred while handling a stream message. This flag is crucial for ensuring that the subscription state for stream order updates is correctly maintained, especially in error scenarios.
1. **Exception Handling Improvement**:
  Added logic to set the `_isSubscribeOnStreamOrderUpdate` flag to false when an exception is caught in the stream message handler. This will skip the snapshot of orders event, preventing potential inconsistencies.
2. **Code Refactoring**:
  Refactored the exception handling block to ensure the flag state is consistently updated and the snapshot of orders event is skipped.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/a

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this change is to enhance the robustness of our application by correctly managing the subscription state for stream order updates. In scenarios where exceptions occur during the handling of stream messages, not setting the `_isSubscribeOnStreamOrderUpdate` flag led to inconsistencies and potential issues with the snapshot of orders event. By ensuring this flag is set correctly, we can avoid processing incomplete or inaccurate order data, thereby maintaining the integrity of our application's data flow.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run all exist tests in repo.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
