### PR TITLE
Fix: Market of Future Security

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
@@ -36,11 +36,12 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             _symbolMapper = new TradeStationSymbolMapper();
         }
 
-        [TestCase("AAPL", "AAPL", TradeStationAssetType.Stock, null, TradeStationOptionType.Call, 0)]
-        [TestCase("ESZ24", "ES", TradeStationAssetType.Future, "2024/12/20", TradeStationOptionType.Call, 0)]
-        [TestCase("TSLA 240510C167.5", "TSLA", TradeStationAssetType.StockOption, "2024/5/10", TradeStationOptionType.Call, 167.5)]
+        [TestCase("AAPL", "AAPL", TradeStationAssetType.Stock, null, TradeStationOptionType.Call, 0, Market.USA)]
+        [TestCase("ESZ24", "ES", TradeStationAssetType.Future, "2024/12/20", TradeStationOptionType.Call, 0, Market.CME)]
+        [TestCase("CTV24", "CT", TradeStationAssetType.Future, "2024/10/1", TradeStationOptionType.Call, 0, Market.ICE)]
+        [TestCase("TSLA 240510C167.5", "TSLA", TradeStationAssetType.StockOption, "2024/5/10", TradeStationOptionType.Call, 167.5, Market.USA)]
         public void ReturnsCorrectLeanSymbol(string symbol, string underlying, TradeStationAssetType assetType,
-            DateTime expirationDate, TradeStationOptionType optionType, decimal strikePrice)
+            DateTime expirationDate, TradeStationOptionType optionType, decimal strikePrice, string expectedMarket)
         {
             var leg = new Leg("", 0m, 0m, 0m, TradeStationTradeActionType.Buy, symbol, underlying, assetType, 0m, expirationDate, optionType, strikePrice);
 
@@ -48,6 +49,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
                 leg.ExpirationDate, leg.StrikePrice, leg.OptionType.ConvertOptionTypeToOptionRight());
 
             Assert.IsNotNull(leanSymbol);
+            Assert.That(leanSymbol.ID.Market, Is.EqualTo(expectedMarket));
         }
 
         private static IEnumerable<TestCaseData> LeanSymbolTestCases

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
                 yield return new TestCaseData(new StopMarketOrderTestParameters(AAPLOption, 15.1m, 15.1m)).SetCategory("Option").SetName("AAPL|OPTION|STOPMARKET");
                 yield return new TestCaseData(new StopLimitOrderTestParameters(AAPLOption, 15.1m, 15.1m)).SetCategory("Option").SetName("AAPL|OPTION|STOPLIMIT");
 
-                var COTTON = Symbol.CreateFuture(Futures.Softs.Cotton2, Market.ICE, new DateTime(2024, 7, 1));
+                var COTTON = Symbol.CreateFuture(Futures.Softs.Cotton2, Market.ICE, new DateTime(2024, 10, 1));
                 yield return new TestCaseData(new LimitOrderTestParameters(COTTON, 72m, 70m)).SetCategory("Future").SetName("COTTON|FUTURE|LIMIT").Explicit("At the first, setup specific `trade-station-account-type` in config file.");
                 yield return new TestCaseData(new StopMarketOrderTestParameters(COTTON, 72m, 70m)).SetCategory("Future").SetName("COTTON|FUTURE|STOPMARKET").Explicit("At the first, setup specific `trade-station-account-type` in config file.");
                 yield return new TestCaseData(new StopLimitOrderTestParameters(COTTON, 72m, 72m)).SetCategory("Future").SetName("COTTON|FUTURE|STOPLIMIT").Explicit("At the first, setup specific `trade-station-account-type` in config file.");

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
@@ -343,7 +343,7 @@ public partial class TradeStationBrokerage : IDataQueueHandler
     /// <param name="symbol">The symbol for which the order book is to be added.</param>
     private void AddOrderBook(Symbol symbol)
     {
-        var exchangeTimeZone = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType).TimeZone;
+        var exchangeTimeZone = symbol.GetSymbolExchangeTimeZone();
         _exchangeTimeZoneByLeanSymbol[symbol] = exchangeTimeZone;
 
         var brokerageSymbol = _symbolMapper.GetBrokerageSymbol(symbol);

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -295,7 +295,7 @@ public partial class TradeStationBrokerage : Brokerage
                     break;
             }
 
-            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()))
+            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)
             {
                 Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(GetAccountHoldings)}: The {leanSymbol} was expired and skipped.");
                 continue;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -295,7 +295,7 @@ public partial class TradeStationBrokerage : Brokerage
                     break;
             }
 
-            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)
+            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)
             {
                 Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(GetAccountHoldings)}: The {leanSymbol} was expired and skipped.");
                 continue;

--- a/QuantConnect.TradeStationBrokerage/TradeStationExtensions.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationExtensions.cs
@@ -17,6 +17,7 @@ using System;
 using System.Threading;
 using QuantConnect.Orders;
 using System.Threading.Tasks;
+using QuantConnect.Securities;
 using System.Collections.Generic;
 using QuantConnect.Orders.TimeInForces;
 using QuantConnect.Brokerages.TradeStation.Models.Enums;
@@ -248,4 +249,19 @@ public static class TradeStationExtensions
             e.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
     }
+
+    /// <summary>
+    /// Retrieves the time zone of the exchange for the given symbol.
+    /// </summary>
+    /// <param name="symbol">The symbol for which to get the exchange time zone.</param>
+    /// <returns>
+    /// The <see cref="NodaTime.DateTimeZone"/> representing the time zone of the exchange
+    /// where the given symbol is traded.
+    /// </returns>
+    /// <remarks>
+    /// This method uses the <see cref="MarketHoursDatabase"/> to fetch the exchange hours
+    /// and extract the time zone information for the provided symbol.
+    /// </remarks>
+    public static NodaTime.DateTimeZone GetSymbolExchangeTimeZone(this Symbol symbol)
+        => MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType).TimeZone;
 }

--- a/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Securities;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -102,6 +103,10 @@ public class TradeStationSymbolMapper : ISymbolMapper
                 var underlying = Symbol.Create(brokerageSymbol, SecurityType.Equity, market);
                 return Symbol.CreateOption(underlying, underlying.ID.Market, SecurityType.Option.DefaultOptionStyle(), optionRight, strike, expirationDate);
             case SecurityType.Future:
+                if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(brokerageSymbol, SecurityType.Future, out market))
+                {
+                    market = DefaultBrokerageModel.DefaultMarketMap[SecurityType.Future];
+                }
                 return Symbol.CreateFuture(brokerageSymbol, market, expirationDate);
             default:
                 throw new NotImplementedException($"{nameof(TradeStationSymbolMapper)}.{nameof(GetLeanSymbol)}: " +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR introduces several key features, improvements, and fixes to enhance the functionality and robustness of our trading system. The changes include:

- Feature: Implementation of `getMarket` for Future Securities.
- Feature: Skipping expired symbols in `GetAccountHoldings`.
- Refactor: Creation of a generic method for `GetSymbolExchangeTimeZone`.
- Fix: Adjustment of tests to handle expired future symbol dates.
- Feature: Addition of tests to validate the market in `GetLeanSymbo`l.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind these changes is to improve the overall efficiency and accuracy of our trading operations. Specifically:

- `getMarket` for Future Securities: This new feature allows for more precise and streamlined market retrieval for future securities.
- **Skipping expired symbols in `GetAccountHoldings`**: By skipping expired symbols, we can avoid unnecessary processing and potential errors in account holdings management.
- **Generic method for `GetSymbolExchangeTimeZone`**: Refactoring to a generic method simplifies the codebase, enhances maintainability, and reduces redundancy.
- **Expired future symbol date fix**: Ensures that our tests accurately reflect real-world scenarios and handle expired future symbols correctly.
- **Market validation in `GetLeanSymbol`**: Adding tests to validate market information

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->.
- Unit tests have been updated and added to cover the new features and changes.
- Manual testing was conducted to verify the correct functionality of the `getMarket` feature for future securities.
- The refactored `GetSymbolExchangeTimeZone` method was tested to ensure it works generically across different use cases.
- Test cases involving expired future symbols were reviewed and adjusted to validate the fixes.
- Validation tests for the market in `GetLeanSymbol` were executed to confirm the correctness of the implementation.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
