### PR TITLE
Fix: combo order handle event message

### DIFF
--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -789,7 +789,7 @@ public partial class TradeStationBrokerage : Brokerage
                         return;
                     // Sometimes, a filled event is received without the ClosedDateTime property set. 
                     // Subsequently, another event is received with the ClosedDateTime property correctly populated.
-                    case TradeStationOrderStatusType.Fll when brokerageOrder.ClosedDateTime != default:
+                    case TradeStationOrderStatusType.Fll:
                     case TradeStationOrderStatusType.Brf:
                         globalLeanOrderStatus = OrderStatus.Filled;
                         break;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -835,7 +835,7 @@ public partial class TradeStationBrokerage : Brokerage
                 }
 
                 var sendFeesOnce = default(bool);
-                foreach (var leg in brokerageOrder.Legs)
+                foreach (var leg in brokerageOrder.Legs.DistinctBy(x => x.Symbol))
                 {
                     var legOrderStatus = globalLeanOrderStatus;
                     // Manually update the order status to 'Filled' because one of the combo order legs is fully filled.

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -929,6 +929,7 @@ public partial class TradeStationBrokerage : Brokerage
                                 Status = OrderStatus.Filled,
                                 FillQuantity = leanOrder.Quantity
                             };
+                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, $"Detected missing fill event for OrderID: {leanOrder.Id} creating inferred filled event."));
                             OnOrderEvent(orderEvent);
                         }
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
1. We should remove the specific condition for the `ClosedDateTime` when we receive a `Filled` event from the TradeStation Server. This is necessary because there are instances where multiple legs orders may be closed without this property. However, if we receive duplicate responses _with and without_ this **property**, we will **skip** **leanOrders** that have already been **filled**.
```
// TradeStation may occasionally send duplicate event messages where the only difference is the order of the legs.
// If the order status is 'Filled', skip processing this message to avoid handling the same event multiple times.
if (leanOrder.Status == OrderStatus.Filled)
{
  continue;
}
```

2. We have added `DistinctBy()` because sometimes the TradeStation server returns the same symbol.
```
JSON response in HandleTradeStationMessage() of OrderUpdate.
{
    ...
    "Legs": [
        {
            "AssetType": "STOCKOPTION",
            "BuyOrSell": "Sell",
            ...
            "StrikePrice": "217.5",
            "Symbol": "AAPL 240920C217.5", <----------
            "Underlying": "AAPL"
        },
        {
            "AssetType": "STOCKOPTION",
            "BuyOrSell": "Sell",
            ...
            "StrikePrice": "217.5",
            "Symbol": "AAPL 240920C217.5", <----------
            "Underlying": "AAPL"
        },
        {
            "AssetType": "STOCKOPTION",
            "BuyOrSell": "Buy",
            ...
            "StrikePrice": "220",
            "Symbol": "AAPL 240920C220",
            "Underlying": "AAPL"
        }
    ],
    "OpenedDateTime": "2024-09-12T17:53:54Z",
    "OrderID": "852697039",
    "OrderType": "Market",
    "PriceUsedForBuyingPower": "7.16",
    "Routing": "Intelligent",
    "Spread": "Butterfly",
    "Status": "FLL",
    "StatusDescription": "Filled",
    "UnbundledRouteFee": "0"
}
```

3. Manually close the orders which have not been filled yet, even though we received a filled response from TradeStation (with duplicate symbol). Then we manually call the orderEvent.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is crucial to make changes that fix bugs in handling Lean Combo Orders to ensure the correct calculation of holdings and proper filling of order events for the user.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the Combo Market Orders' cover algorithm and review the holdings balance after approximately 100 orders have been executed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
