### PR TITLE
Fix: Handle Missed Asset Type in `GetPositions()`

### DIFF
--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -311,7 +311,7 @@ public partial class TradeStationBrokerage : Brokerage
                 if (TryCreateLeanOrder(order, leg, out var leanOrder))
                 {
                     leanOrders.Add(leanOrder);
-            }
+                }
             }
             else
             {
@@ -324,14 +324,14 @@ public partial class TradeStationBrokerage : Brokerage
                     if (TryCreateLeanOrder(order, leg, out var leanOrder, groupOrderManager))
                     {
                         tempLegOrders.Add(leanOrder);
-                }
+                    }
                     else
                     {
                         // If any leg fails to create a Lean order, clear tempLegOrders to prevent partial group orders.
                         tempLegOrders.Clear();
                         break;
-            }
-        }
+                    }
+                }
 
                 if (tempLegOrders.Count > 0)
                 {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -362,13 +362,6 @@ public partial class TradeStationBrokerage : Brokerage
                 case TradeStationAssetType.Stock:
                     leanSymbol = _symbolMapper.GetLeanSymbol(position.Symbol, SecurityType.Equity, Market.USA);
                     break;
-                case TradeStationAssetType.Index:
-                    leanSymbol = _symbolMapper.GetLeanSymbol(position.Symbol, SecurityType.Index, Market.USA);
-                    break;
-                case TradeStationAssetType.IndexOption:
-                    var indexOptionParam = _symbolMapper.ParsePositionOptionSymbol(position.Symbol);
-                    leanSymbol = _symbolMapper.GetLeanSymbol(indexOptionParam.symbol, SecurityType.IndexOption, Market.USA, indexOptionParam.expiryDate, indexOptionParam.strikePrice, indexOptionParam.optionRight == 'C' ? OptionRight.Call : OptionRight.Put);
-                    break;
                 case TradeStationAssetType.StockOption:
                     var optionParam = _symbolMapper.ParsePositionOptionSymbol(position.Symbol);
                     leanSymbol = _symbolMapper.GetLeanSymbol(optionParam.symbol, SecurityType.Option, Market.USA, optionParam.expiryDate, optionParam.strikePrice, optionParam.optionRight == 'C' ? OptionRight.Call : OptionRight.Put);
@@ -378,7 +371,7 @@ public partial class TradeStationBrokerage : Brokerage
                     continue;
             }
 
-            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option or SecurityType.IndexOption && leanSymbol.ID.Date.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)
+            if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)
             {
                 Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(GetAccountHoldings)}: The {leanSymbol} was expired and skipped.");
                 continue;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -347,6 +347,9 @@ public partial class TradeStationBrokerage : Brokerage
                     var optionParam = _symbolMapper.ParsePositionOptionSymbol(position.Symbol);
                     leanSymbol = _symbolMapper.GetLeanSymbol(optionParam.symbol, SecurityType.Option, Market.USA, optionParam.expiryDate, optionParam.strikePrice, optionParam.optionRight == 'C' ? OptionRight.Call : OptionRight.Put);
                     break;
+                default:
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, 1, $"The asset type '{position.AssetType}' for symbol '{position.Symbol}' is not supported. This position has been skipped."));
+                    continue;
             }
 
             if (leanSymbol.SecurityType is SecurityType.Future or SecurityType.Option && leanSymbol.ID.Date.Date < DateTime.UtcNow.ConvertFromUtc(leanSymbol.GetSymbolExchangeTimeZone()).Date)

--- a/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
@@ -102,9 +102,6 @@ public class TradeStationSymbolMapper : ISymbolMapper
             case SecurityType.Option:
                 var underlying = Symbol.Create(brokerageSymbol, SecurityType.Equity, market);
                 return Symbol.CreateOption(underlying, underlying.ID.Market, SecurityType.Option.DefaultOptionStyle(), optionRight, strike, expirationDate);
-            case SecurityType.IndexOption:
-                var underlyingIndex = Symbol.Create(brokerageSymbol, SecurityType.Index, market);
-                return Symbol.CreateOption(underlyingIndex, underlyingIndex.ID.Market, SecurityType.IndexOption.DefaultOptionStyle(), optionRight, strike, expirationDate);
             case SecurityType.Future:
                 if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(brokerageSymbol, SecurityType.Future, out market))
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Failure to handle unsupported asset type in `GetPositions()` resulted in a null reference exception for the user.
We have skipped not supported SecurityTypes and log to user message.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #33 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- reduce the amount of bugs
- help users to use this brokerage with different types of Securities.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Purchase various securities using the TS application and debug the results.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
