### PR TITLE
Feature: config `delayed streaming data`

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
@@ -148,6 +148,11 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
 
                 var VIXWeeklyOption = Symbol.CreateOption(indexUnderlying2, "VIXW", Market.USA, SecurityType.IndexOption.DefaultOptionStyle(), OptionRight.Call, 14.5m, new DateTime(2024, 12, 11));
                 yield return new TestCaseData(VIXWeeklyOption, "VIXW 241211C14.5");
+
+                // GOOGL - Equity
+                var GOOGL = Symbol.Create("GOOGL", SecurityType.Equity, Market.USA);
+                yield return new TestCaseData(GOOGL, "GOOGL");
+                yield return new TestCaseData(Symbol.CreateOption(GOOGL, Market.USA, SecurityType.Option.DefaultOptionStyle(), OptionRight.Put, 180m, new DateTime(2024, 12, 06)), "GOOGL 241206P180");
             }
 
         }

--- a/QuantConnect.TradeStationBrokerage.Tests/config.json
+++ b/QuantConnect.TradeStationBrokerage.Tests/config.json
@@ -6,5 +6,6 @@
   "trade-station-refresh-token": "",
   "trade-station-api-url": "https://sim-api.tradestation.com",
   "trade-station-account-type": "Margin",
-  "trade-station-account-id": ""
+  "trade-station-account-id": "",
+  "trade-station-enable-delayed-streaming-data": false
 }

--- a/QuantConnect.TradeStationBrokerage/Models/TradeStationQuoteSnapshot.cs
+++ b/QuantConnect.TradeStationBrokerage/Models/TradeStationQuoteSnapshot.cs
@@ -327,7 +327,7 @@ public readonly struct MarketFlag
     /// <summary>
     /// Is delayed.
     /// </summary>
-    public bool IsDelayed { get; }
+    public bool? IsDelayed { get; }
 
     /// <summary>
     /// Is halted.
@@ -338,4 +338,19 @@ public readonly struct MarketFlag
     /// Is hard to borrow.
     /// </summary>
     public bool IsHardToBorrow { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarketFlag"/> struct with the specified market flags.
+    /// </summary>
+    /// <param name="isBats">A value indicating whether the market is BATS.</param>
+    /// <param name="isDelayed">A nullable value indicating whether the market data is delayed.</param>
+    /// <param name="isHalted">A value indicating whether the market is halted.</param>
+    /// <param name="isHardToBorrow">A value indicating whether the symbol is hard to borrow.</param>
+    public MarketFlag(bool isBats, bool? isDelayed, bool isHalted, bool isHardToBorrow)
+    {
+        IsBats = isBats;
+        IsDelayed = isDelayed;
+        IsHalted = isHalted;
+        IsHardToBorrow = isHardToBorrow;
+    }
 }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -277,7 +277,8 @@ public partial class TradeStationBrokerage : Brokerage
             _aggregator = Composer.Instance.GetExportedValueByTypeName<IDataAggregator>(aggregatorName);
         }
 
-        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator);
+        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator,
+            Config.GetBool("trade-station-enable-delayed-streaming-data"), OnBrokerageMessageEventHandler);
 
         _routes = new Lazy<Dictionary<SecurityType, ReadOnlyCollection<Route>>>(() =>
         {
@@ -729,6 +730,13 @@ public partial class TradeStationBrokerage : Brokerage
 
         return _symbolMapper.SupportedSecurityType.Contains(symbol.SecurityType);
     }
+
+    /// <summary>
+    /// Handles brokerage message events by invoking the appropriate message processing logic.
+    /// </summary>
+    /// <param name="_">The sender of the event, typically unused in this implementation.</param>
+    /// <param name="brokerageMessageEvent">The event data containing details of the brokerage message, such as type and content.</param>
+    private void OnBrokerageMessageEventHandler(object _, BrokerageMessageEvent brokerageMessageEvent) => OnMessage(brokerageMessageEvent);
 
     /// <summary>
     /// Determines if the provided <paramref name="securityType"/> matches the <see cref="TradeStationAccountType"/>.

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -86,11 +86,6 @@ public partial class TradeStationBrokerage : Brokerage
     private readonly ManualResetEvent _orderUpdateEndManualResetEvent = new(false);
 
     /// <summary>
-    /// Indicates whether delayed streaming data is enabled for the application.
-    /// </summary>
-    private readonly bool _enableDelayedStreamingData = Config.GetBool("trade-station-enable-delayed-streaming-data");
-
-    /// <summary>
     /// A thread-safe dictionary to track the response result submission status by brokerage ID.
     /// </summary>
     /// <remarks>
@@ -282,7 +277,7 @@ public partial class TradeStationBrokerage : Brokerage
             _aggregator = Composer.Instance.GetExportedValueByTypeName<IDataAggregator>(aggregatorName);
         }
 
-        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator, _enableDelayedStreamingData, OnBrokerageMessageEventHandler);
+        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator, OnBrokerageMessageEventHandler);
 
         _routes = new Lazy<Dictionary<SecurityType, ReadOnlyCollection<Route>>>(() =>
         {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -86,6 +86,11 @@ public partial class TradeStationBrokerage : Brokerage
     private readonly ManualResetEvent _orderUpdateEndManualResetEvent = new(false);
 
     /// <summary>
+    /// Indicates whether delayed streaming data is enabled for the application.
+    /// </summary>
+    private readonly bool _enableDelayedStreamingData = Config.GetBool("trade-station-enable-delayed-streaming-data");
+
+    /// <summary>
     /// A thread-safe dictionary to track the response result submission status by brokerage ID.
     /// </summary>
     /// <remarks>
@@ -277,8 +282,7 @@ public partial class TradeStationBrokerage : Brokerage
             _aggregator = Composer.Instance.GetExportedValueByTypeName<IDataAggregator>(aggregatorName);
         }
 
-        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator,
-            Config.GetBool("trade-station-enable-delayed-streaming-data"), OnBrokerageMessageEventHandler);
+        SubscriptionManager = new TradeStationBrokerageMultiStreamSubscriptionManager(_tradeStationApiClient, _symbolMapper, _aggregator, _enableDelayedStreamingData, OnBrokerageMessageEventHandler);
 
         _routes = new Lazy<Dictionary<SecurityType, ReadOnlyCollection<Route>>>(() =>
         {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerageMultiStreamSubscriptionManager.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerageMultiStreamSubscriptionManager.cs
@@ -22,6 +22,7 @@ using QuantConnect.Util;
 using QuantConnect.Logging;
 using System.Threading.Tasks;
 using QuantConnect.Data.Market;
+using QuantConnect.Configuration;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using QuantConnect.Brokerages.TradeStation.Api;
@@ -89,7 +90,7 @@ namespace QuantConnect.Brokerages.TradeStation
         /// <summary>
         /// Indicates whether delayed streaming data is enabled for the application.
         /// </summary>
-        private readonly bool _enableDelayedStreamingData;
+        private readonly bool _enableDelayedStreamingData = Config.GetBool("trade-station-enable-delayed-streaming-data");
 
         /// <summary>
         /// Manages multi-stream subscriptions for TradeStation Brokerage, allowing for real-time and delayed market data streaming.
@@ -105,13 +106,12 @@ namespace QuantConnect.Brokerages.TradeStation
         /// The event handler for receiving and processing brokerage messages, such as connection status updates or error notifications.
         /// </param>
         public TradeStationBrokerageMultiStreamSubscriptionManager(TradeStationApiClient tradeStationApiClient, TradeStationSymbolMapper symbolMapper, IDataAggregator aggregator,
-            bool enableDelayedStreamingData, EventHandler<BrokerageMessageEvent> brokerageEventHandler)
+            EventHandler<BrokerageMessageEvent> brokerageEventHandler)
         {
             _aggregator = aggregator;
             _symbolMapper = symbolMapper;
             _tradeStationApiClient = tradeStationApiClient;
             _brokerageEventHandler = brokerageEventHandler;
-            _enableDelayedStreamingData = enableDelayedStreamingData;
 
             SubscribeImpl = (symbols, _) => Subscribe(symbols);
             UnsubscribeImpl = (symbols, _) => UnSubscribe(symbols);

--- a/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
@@ -84,7 +84,7 @@ public class TradeStationSymbolMapper : ISymbolMapper
     /// <example>{AAPL 240510C167.5}</example>
     private string GenerateBrokerageOption(Symbol symbol)
     {
-        return $"{symbol.ID.Symbol} {symbol.ID.Date:yyMMdd}{symbol.ID.OptionRight.ToString()[0]}{symbol.ID.StrikePrice}";
+        return $"{symbol.Canonical.Value.Replace("?", string.Empty)} {symbol.ID.Date:yyMMdd}{symbol.ID.OptionRight.ToString()[0]}{symbol.ID.StrikePrice}";
     }
 
     /// <summary>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
#### 1. New config `"trade-station-enable-delayed-streaming-data"`
Add the new `"trade-station-enable-delayed-streaming-data"` config, which helps detect delayed data for symbols.

Example of delay JSON (take attention to `"IsDelayed"`):
> receive in `public async IAsyncEnumerable<Quote> StreamQuotes(...) {}`
```
{
    "Symbol": "SPY",
    "Open": "589.39001",
    "High": "591.13",
    "Low": "580.5",
    "PreviousClose": "586.08002",
    "Last": "584.5638",
    "Ask": "584.58",
    "AskSize": "400",
    "Bid": "584.55",
    "BidSize": "400",
    "NetChange": "-1.51622",
    "NetChangePct": "-0.0026",
    "High52Week": "609.07001",
    "High52WeekTimestamp": "2024-12-06T00:00:00Z",
    "Low52Week": "466.42999",
    "Low52WeekTimestamp": "2024-01-05T00:00:00Z",
    "Volume": "40914141",
    "PreviousVolume": "58314654",
    "Close": "584.56378",
    "DailyOpenInterest": "0",
    "TradeTime": "2025-01-02T20:46:33Z",
    "TickSizeTier": "0",
    "MarketFlags": {
        "IsDelayed": true,
        "IsHardToBorrow": false,
        "IsBats": false,
        "IsHalted": false
    },
    "MarketFlagsDisplay": "(D)",
    "LastSize": "100",
    "LastVenue": "NASDAQ",
    "VWAP": "585.143532796451"
}
```

TradeStation Info:
- [Market data prices](https://www.tradestation.com/pricing/market-data-pricing/)
- [Manage your subscription in the account](https://my.tradestation.com/manage)

![image](https://github.com/user-attachments/assets/feca57bd-b963-489e-a1a7-4a74300c8ea0)

#### 2. Fix GetBrokekerage Option Symbol
The Lean uses map_file which creates an Option based the on first ancient ticker.

![image](https://github.com/user-attachments/assets/9ee73b81-5dbe-4446-b20c-16f65bfb7ba0)


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/a

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent user confussion of getting specific data.

### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run a streaming test in the test project and observe the result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
