### PR TITLE
Feat: change `MessageType` on `Warning` instead of `Error` in UpdateOrder()

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -810,7 +810,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Brokerage.Message += (_, brokerageMessage) =>
             {
                 Assert.AreEqual(BrokerageMessageType.Warning, brokerageMessage.Type);
-                Assert.AreEqual("Failed to Cancel/Replace order: Not an open order.", brokerageMessage.Message);
+                Assert.IsTrue(brokerageMessage.Message.StartsWith("Failed to Replace order:", StringComparison.InvariantCultureIgnoreCase));
             };
 
             Brokerage.OrdersStatusChanged += (_, orderEvents) =>

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -810,7 +810,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Brokerage.Message += (_, brokerageMessage) =>
             {
                 Assert.AreEqual(BrokerageMessageType.Warning, brokerageMessage.Type);
-                Assert.IsTrue(brokerageMessage.Message.StartsWith("Failed to Replace order:", StringComparison.InvariantCultureIgnoreCase));
+                Assert.IsTrue(brokerageMessage.Message.StartsWith("Failed to update Order: OrderId:", StringComparison.InvariantCultureIgnoreCase));
             };
 
             Brokerage.OrdersStatusChanged += (_, orderEvents) =>

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageTests.cs
@@ -794,6 +794,73 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             }
         }
 
+        [Test]
+        public void UpdateAlreadyCanceledOrder()
+        {
+            Log.Trace("UPDATE ALREADY CANCELED ORDER");
+            var symbol = Symbols.AAPL;
+            var lastPrice = _brokerage.GetPrice(symbol).Last;
+            var limitPrice = SubtractAndRound(lastPrice, 0.5m);
+            var limitOrder = new LimitOrder(Symbols.AAPL, 1, limitPrice, DateTime.UtcNow);
+            OrderProvider.Add(limitOrder);
+
+            var submittedResetEvent = new AutoResetEvent(false);
+            var cancelledResetEvent = new AutoResetEvent(false);
+
+            Brokerage.Message += (_, brokerageMessage) =>
+            {
+                Assert.AreEqual(BrokerageMessageType.Warning, brokerageMessage.Type);
+                Assert.AreEqual("Failed to Cancel/Replace order: Not an open order.", brokerageMessage.Message);
+            };
+
+            Brokerage.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                var orderEvent = orderEvents[0];
+
+                Log.Trace("");
+                Log.Trace($"{nameof(UpdateAlreadyCanceledOrder)}.OrderEvent.Status: {orderEvent.Status}");
+                Log.Trace("");
+
+                switch (orderEvent.Status)
+                {
+                    case OrderStatus.Submitted:
+                        submittedResetEvent.Set();
+                        break;
+                    case OrderStatus.Canceled:
+                        cancelledResetEvent.Set();
+                        break;
+                }
+            };
+
+            if (!Brokerage.PlaceOrder(limitOrder))
+            {
+                Assert.Fail("Brokerage failed to place the order: " + limitOrder);
+            }
+
+            if (!submittedResetEvent.WaitOne(TimeSpan.FromSeconds(5)))
+            {
+                Assert.Fail($"{nameof(PlaceLimitOrderAndUpdate)}: the brokerage doesn't return {OrderStatus.Submitted}");
+            }
+
+            var order = OrderProvider.GetOrderById(1);
+            if (!Brokerage.CancelOrder(order))
+            {
+                Assert.Fail("Brokerage failed to cancel the order: " + order);
+            }
+
+            if (!cancelledResetEvent.WaitOne(TimeSpan.FromSeconds(5)))
+            {
+                Assert.Fail($"{nameof(PlaceLimitOrderAndUpdate)}: the brokerage doesn't return {OrderStatus.Canceled}");
+            }
+
+            order.ApplyUpdateOrderRequest(new UpdateOrderRequest(DateTime.UtcNow, order.Id, new() { LimitPrice = limitPrice - 0.01m }));
+
+            if (Brokerage.UpdateOrder(order))
+            {
+                Assert.Fail("Brokerage can not update already cancelled order: " + order);
+            }
+        }
+
         /// <summary>
         /// Adds a value to a base number and rounds the result to the nearest specified increment.
         /// </summary>

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -176,16 +176,8 @@ public class TradeStationApiClient : IDisposable
     /// </param>
     public async Task<bool> CancelOrder(string orderID)
     {
-        try
-        {
-            await RequestAsync<TradeStationAccount>(_baseUrl, $"/v3/orderexecution/orders/{orderID}", HttpMethod.Delete);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex);
-            return false;
-        }
+        await RequestAsync<TradeStationAccount>(_baseUrl, $"/v3/orderexecution/orders/{orderID}", HttpMethod.Delete);
+        return true;
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -632,8 +632,7 @@ public partial class TradeStationBrokerage : Brokerage
             }
             catch (Exception exception)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "UpdateOrderInvalid", exception.Message));
-                response = false;
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateOrderInvalid", exception.Message));
             }
         });
         return response;

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -632,7 +632,7 @@ public partial class TradeStationBrokerage : Brokerage
             }
             catch (Exception exception) when (exception.Message.Equals("Failed to Cancel/Replace order: Not an open order.", StringComparison.InvariantCultureIgnoreCase))
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", exception.Message));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", "Failed to Replace order: " + order));
             }
             catch (Exception exception)
             {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -632,7 +632,7 @@ public partial class TradeStationBrokerage : Brokerage
             }
             catch (Exception exception) when (exception.Message.Equals("Failed to Cancel/Replace order: Not an open order.", StringComparison.InvariantCultureIgnoreCase))
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", "Failed to Replace order: " + order));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", $"Failed to update Order: OrderId: {order.Id} (BrokerId: {brokerageOrderId}) for {order.Symbol}, the order is already closed"));
             }
             catch (Exception exception)
             {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -630,9 +630,13 @@ public partial class TradeStationBrokerage : Brokerage
                 response = true;
                 _updateSubmittedResponseResultByBrokerageID[brokerageOrderId] = true;
             }
+            catch (Exception exception) when (exception.Message.Equals("Failed to Cancel/Replace order: Not an open order.", StringComparison.InvariantCultureIgnoreCase))
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", exception.Message));
+            }
             catch (Exception exception)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateOrderInvalid", exception.Message));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "UpdateOrderInvalid", exception.Message));
             }
         });
         return response;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Update the `MessageType` from `Error` to `Warning` to avoid unnecessary stops of the Lean algorithm.
Display new warning to user:
1. `UpdateOrder()`:
```
Brokerage.OnMessage(): Warning - Code: UpdateNotOpenOrder - Failed to update Order: OrderId: 1 (BrokerId: 882518333) for AAPL R735QTJ8XC9X, the order is already closed
```
2. `CancleOrder()`:
```
Brokerage.OnMessage(): Warning - Code: CancelNotOpenOrder - Failed to cancel Order: OrderId: 1 (BrokerId: 882518259) for INTL Y3ZDTMB96WRP, the order is already closed
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #44

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix all bugs to make the brokerage better.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test with trading update tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
