### PR TITLE
Fix: handle `Cancel` already `Partial Filled` orders

### DIFF
--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -886,6 +886,10 @@ public partial class TradeStationBrokerage : Brokerage
                         eventMessage = "Expired";
                         globalLeanOrderStatus = OrderStatus.Canceled;
                         break;
+                    case TradeStationOrderStatusType.FLP:
+                        eventMessage = "PartiallyFilled (Cancelled)";
+                        globalLeanOrderStatus = OrderStatus.Canceled;
+                        break;
                     // Sometimes, a Out event is received without the ClosedDateTime property set.
                     // Subsequently, another event is received with the ClosedDateTime property correctly populated.
                     case TradeStationOrderStatusType.Out when brokerageOrder.ClosedDateTime != default:
@@ -898,9 +902,9 @@ public partial class TradeStationBrokerage : Brokerage
                         globalLeanOrderStatus = OrderStatus.Canceled;
                         break;
                     default:
-                        Log.Debug($"{nameof(TradeStationBrokerage)}.{nameof(HandleTradeStationMessage)}.TradeStationStreamStatus: {json}");
+                        Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(HandleTradeStationMessage)}.TradeStationStreamStatus: {json}");
                         return;
-                };
+                }
 
                 var leanOrders = new List<Order>();
                 if (!TryGetOrRemoveCrossZeroOrder(brokerageOrder.OrderID, globalLeanOrderStatus, out var crossZeroLeanOrder))

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -887,7 +887,7 @@ public partial class TradeStationBrokerage : Brokerage
                         globalLeanOrderStatus = OrderStatus.Canceled;
                         break;
                     case TradeStationOrderStatusType.FLP:
-                        eventMessage = "PartiallyFilled (Cancelled)";
+                        eventMessage = "PartiallyFilled (Canceled)";
                         globalLeanOrderStatus = OrderStatus.Canceled;
                         break;
                     // Sometimes, a Out event is received without the ClosedDateTime property set.


### PR DESCRIPTION
#### Description
- Log all unknown responses in sys-logs.
- We have missed to handle TradeStation Status: `FLP` order update event, the JSON example:
```
{
    "AccountID": "XXXXXXXX",
    "ClosedDateTime": "2025-12-16T15:51:21Z",
    "CommissionFee": "0.0011",
    "Currency": "USD",
    "Duration": "GTC",
    "FilledPrice": "0.0226",
    "GoodTillDate": "2026-03-16T00:00:00Z",
    "Legs": [
        {
            "AssetType": "STOCK",
            "BuyOrSell": "Buy",
            "ExecQuantity": "1",
            "ExecutionPrice": "0.0226",
            "OpenOrClose": "Open",
            "QuantityOrdered": "2401",
            "QuantityRemaining": "0",
            "Symbol": "ALUR.W"
        }
    ],
    "LimitPrice": "0.024",
    "OpenedDateTime": "2025-12-16T15:51:21Z",
    "OrderID": "1216638408",
    "OrderType": "Limit",
    "PriceUsedForBuyingPower": "0.024",
    "Routing": "Intelligent",
    "Status": "FLP",
    "StatusDescription": "Partial Fill (UROut)",
    "UnbundledRouteFee": "0"
}
```

#### ⚠The simulation environment restriction ⚠
<img width="278" height="277" alt="image" src="https://github.com/user-attachments/assets/f66fb0d1-314e-4d5f-88bc-67efa887cb21" />


#### Related Issue
closes #66

#### Motivation and Context
Resolve this urgent bug issue.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
- Run the specific test and wait for the result.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
