### PR TITLE
Fix: lock `access-token` handling and expiration logic

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
@@ -456,6 +456,35 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Assert.IsNotEmpty(positions.Errors);
         }
 
+        [Test]
+        public void DeserializeTradeStationAccessToken()
+        {
+            var beforeDeserialization = DateTime.UtcNow;
+
+            var json = @"{
+        ""access_token"": ""test_access_token"",
+        ""id_token"": ""test_id_token"",
+        ""scope"": ""openid profile MarketData ReadAccount Trade Matrix OptionSpreads offline_access"",
+        ""expires_in"": 1200,
+        ""token_type"": ""Bearer""
+    }";
+
+            var res = JsonConvert.DeserializeObject<TradeStationAccessToken>(json);
+
+            Assert.IsNotNull(res);
+
+            Assert.AreEqual("test_access_token", res.AccessToken);
+            Assert.AreEqual("test_id_token", res.IdToken);
+            Assert.AreEqual("openid profile MarketData ReadAccount Trade Matrix OptionSpreads offline_access", res.Scope);
+            Assert.AreEqual("Bearer", res.TokenType);
+
+            var expectedExpiryMin = beforeDeserialization.AddSeconds(1200);
+            var expectedExpiryMax = DateTime.UtcNow.AddSeconds(1200);
+            Assert.That(res.ExpiresIn, Is.InRange(expectedExpiryMin, expectedExpiryMax));
+
+            Assert.IsFalse(res.IsExpired);
+        }
+
         public static TradeStationApiClient CreateTradeStationApiClient()
         {
             var clientId = Config.Get("trade-station-client-id");

--- a/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
@@ -179,15 +179,18 @@ public class TokenRefreshHandler : DelegatingHandler
             return _tradeStationAccessToken;
         }
 
+        var newToken = default(TradeStationAccessToken);
         if (string.IsNullOrEmpty(_refreshToken))
         {
-            _tradeStationAccessToken = await GetAuthenticateToken(cancellationToken);
-            _refreshToken = _tradeStationAccessToken.RefreshToken;
+            newToken = await GetAuthenticateToken(cancellationToken);
+            _refreshToken = newToken.RefreshToken;
         }
         else
         {
-            _tradeStationAccessToken = await RefreshAccessToken(_refreshToken, cancellationToken);
+            newToken = await RefreshAccessToken(_refreshToken, cancellationToken);
         }
+
+        _tradeStationAccessToken = newToken;
 
         return _tradeStationAccessToken;
     }

--- a/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TokenRefreshHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -190,9 +190,7 @@ public class TokenRefreshHandler : DelegatingHandler
             newToken = await RefreshAccessToken(_refreshToken, cancellationToken);
         }
 
-        _tradeStationAccessToken = newToken;
-
-        return _tradeStationAccessToken;
+        return _tradeStationAccessToken = newToken;
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage/Models/TradeStationAccessToken.cs
+++ b/QuantConnect.TradeStationBrokerage/Models/TradeStationAccessToken.cs
@@ -51,10 +51,15 @@ public class TradeStationAccessToken
     public string Scope { get; }
 
     /// <summary>
-    /// Gets the expiration time of the token in seconds.
+    /// The UTC datetime when this token expires.
+    /// Computed as DateTime.UtcNow + expires_in seconds at construction time.
     /// </summary>
-    [JsonProperty("expires_in")]
-    public int ExpiresIn { get; }
+    public DateTime ExpiresIn { get; }
+
+    /// <summary>
+    /// Returns true if the token is expired or within a 30-second safety buffer.
+    /// </summary>
+    public bool IsExpired => DateTime.UtcNow >= ExpiresIn.AddSeconds(-30);
 
     /// <summary>
     /// Gets the token type.
@@ -71,13 +76,13 @@ public class TradeStationAccessToken
     /// <param name="scope">The scope.</param>
     /// <param name="expiresIn">The expiration time of the token in seconds.</param>
     /// <param name="tokenType">The token type.</param>
-    public TradeStationAccessToken(string accessToken, string refreshToken, string idToken, string scope, int expiresIn, string tokenType)
+    public TradeStationAccessToken(string accessToken, string refreshToken, string idToken, string scope, [JsonProperty("expires_in")] int expiresIn, string tokenType)
     {
         AccessToken = accessToken;
         RefreshToken = refreshToken;
         IdToken = idToken;
         Scope = scope;
-        ExpiresIn = expiresIn;
+        ExpiresIn = DateTime.UtcNow.AddSeconds(expiresIn);
         TokenType = tokenType;
     }
 }


### PR DESCRIPTION
#### Description
We have found that when a user tries to place orders in parallel, the handling of the refresh `access token` doesn't work as expected.
The PR adds a specific synchronization construct that helps prevent multiple refreshes of the access token.

<img width="1873" height="722" alt="image" src="https://github.com/user-attachments/assets/1d9c7330-89ed-4533-a63c-8665197ab9ea" />

#### Related Issue
N/a

#### Motivation and Context
Let's fix the bugs and make the TS a less buggy place!

#### Requires Documentation Change
N/a

#### How Has This Been Tested?
- Add a deserialization test to ensure the DTO was not broken.
- The second test I have run `UpdateOrder()` in parallel.
<img width="1860" height="817" alt="image" src="https://github.com/user-attachments/assets/838f8c99-7dcb-41ee-8ae4-6a3c513d47a1" />

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
