### PR TITLE
fix: avoid lock recursion in cross-zero order placement

### DIFF
--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -532,25 +532,46 @@ public partial class TradeStationBrokerage : Brokerage
         var symbol = _symbolMapper.GetBrokerageSymbol(crossZeroOrderRequest.LeanOrder.Symbol);
         var tradeAction = ConvertDirection(crossZeroOrderRequest.LeanOrder.SecurityType, crossZeroOrderRequest.OrderPosition);
 
+        // First-part call (isPlaceOrderWithLeanEvent == true) is invoked synchronously from PlaceOrder,
+        // which already holds _messageHandler.WithLockedStream — re-entering would throw LockRecursionException
+        // because the underlying ReaderWriterLockSlim is created with LockRecursionPolicy.NoRecursion.
+        // Second-part call (isPlaceOrderWithLeanEvent == false) runs from Brokerage.TryHandleRemainingCrossZeroOrder
+        // on a Task.Run with no outer stream lock, so we must take the lock here so the new BrokerId and
+        // _skipWebSocketUpdatesForLeanOrders are registered before any WS event for that brokerage ID is dispatched.
+        if (isPlaceOrderWithLeanEvent)
+        {
+            return PlaceCrossZeroOrderInternal(crossZeroOrderRequest, symbol, tradeAction, isPlaceOrderWithLeanEvent);
+        }
+
         var crossZeroOrderResponse = default(CrossZeroOrderResponse);
         _messageHandler.WithLockedStream(() =>
         {
-            // PlaceOrderCommon will not check the order type. Should this call PlaceTradeStationOrder?
-            var (trailingAmount, trailingAsPercentage) = crossZeroOrderRequest.LeanOrder.GetTrailingStopInfo();
-            var response = PlaceOrderCommon(new List<Order> { crossZeroOrderRequest.LeanOrder }, crossZeroOrderRequest.OrderType, crossZeroOrderRequest.LeanOrder.TimeInForce,
-                crossZeroOrderRequest.AbsoluteOrderQuantity, tradeAction, symbol, crossZeroOrderRequest.LeanOrder.GetLimitPrice(), crossZeroOrderRequest.LeanOrder.GetStopPrice(),
-                trailingAmount, trailingAsPercentage, isPlaceOrderWithLeanEvent);
-
-            if (response == null || !response.Value.Orders.Any())
-            {
-                crossZeroOrderResponse = new CrossZeroOrderResponse(string.Empty, false);
-                return;
-            }
-
-            var brokerageId = response.Value.Orders.Single().OrderID;
-            crossZeroOrderResponse = new CrossZeroOrderResponse(brokerageId, true);
+            crossZeroOrderResponse = PlaceCrossZeroOrderInternal(crossZeroOrderRequest, symbol, tradeAction, isPlaceOrderWithLeanEvent);
         });
         return crossZeroOrderResponse;
+    }
+
+    /// <summary>
+    /// Submits the cross-zero order leg to TradeStation and shapes the response.
+    /// </summary>
+    /// <remarks>
+    /// Caller is responsible for holding <c>_messageHandler.WithLockedStream</c> when needed
+    /// (see <see cref="PlaceCrossZeroOrder"/>). PlaceOrderCommon will not check the order type.
+    /// </remarks>
+    private CrossZeroOrderResponse PlaceCrossZeroOrderInternal(CrossZeroFirstOrderRequest crossZeroOrderRequest, string symbol, string tradeAction, bool isPlaceOrderWithLeanEvent)
+    {
+        var (trailingAmount, trailingAsPercentage) = crossZeroOrderRequest.LeanOrder.GetTrailingStopInfo();
+        var response = PlaceOrderCommon(new List<Order> { crossZeroOrderRequest.LeanOrder }, crossZeroOrderRequest.OrderType, crossZeroOrderRequest.LeanOrder.TimeInForce,
+            crossZeroOrderRequest.AbsoluteOrderQuantity, tradeAction, symbol, crossZeroOrderRequest.LeanOrder.GetLimitPrice(), crossZeroOrderRequest.LeanOrder.GetStopPrice(),
+            trailingAmount, trailingAsPercentage, isPlaceOrderWithLeanEvent);
+
+        if (response == null || !response.Value.Orders.Any())
+        {
+            return new CrossZeroOrderResponse(string.Empty, false);
+        }
+
+        var brokerageId = response.Value.Orders.Single().OrderID;
+        return new CrossZeroOrderResponse(brokerageId, true);
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
`TradeStationBrokerage.PlaceCrossZeroOrder` re-entered `_messageHandler.WithLockedStream` while the outer `PlaceOrder` already held it, throwing `LockRecursionException` (the underlying `ReaderWriterLockSlim` uses `LockRecursionPolicy.NoRecursion`). The first-part path now skips the inner lock; the second-part path keeps it so the new `BrokerId` and `_skipWebSocketUpdatesForLeanOrders` flag are registered before any WS event for that brokerage ID is dispatched.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
Live cross-zero orders (e.g. `MNQ18M26` flip from long to short) are rejected locally with:

```
ERROR:: TradeStationBrokerage.PlaceOrder: System.Threading.LockRecursionException: Recursive read lock acquisitions not allowed in this mode.
   at System.Threading.ReaderWriterLockSlim.EnterReadLock()
   at QuantConnect.Brokerages.BrokerageConcurrentMessageHandler`1.ReaderWriterLockWrapper.EnterWriteLock()
   at QuantConnect.Brokerages.BrokerageConcurrentMessageHandler`1.WithLockedStream(Action code)
   at QuantConnect.Brokerages.TradeStation.TradeStationBrokerage.PlaceCrossZeroOrder(...)
   at QuantConnect.Brokerages.Brokerage.TryCrossZeroPositionOrder(Order order, Decimal holdingQuantity)
   at QuantConnect.Brokerages.TradeStation.TradeStationBrokerage.<>c__DisplayClass38_0.<PlaceOrder>b__0()
   at QuantConnect.Brokerages.BrokerageConcurrentMessageHandler`1.WithLockedStream(Action code)
   at QuantConnect.Brokerages.TradeStation.TradeStationBrokerage.PlaceOrder(Order order)
```

Concurrent processing was enabled in #75, which switched the message handler to a `ReaderWriterLockSlim(NoRecursion)`. The first-part of a cross-zero order travels `PlaceOrder → WithLockedStream → PlaceTradeStationOrder → TryCrossZeroPositionOrder → PlaceCrossZeroOrder`, and the override re-acquired the same lock on the same thread.

Sibling brokerages (Alpaca, Tradier) do not re-enter `WithLockedStream` inside their `PlaceCrossZeroOrder` override.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local replay of the failing strategy: `NVDA` Sell-to-flip (existing long 1 → submit Sell -2) - the order now reaches TradeStation instead of being marked `Invalid` with the recursion message.
- Existing `QuantConnect.TradeStationBrokerage.Tests` suite still passes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`