### PR TITLE
fix: downgrade prior-stop-triggered update reject to a one-time warning

### DIFF
--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -169,6 +169,16 @@ public partial class TradeStationBrokerage : Brokerage
     private readonly Dictionary<string, Exchange> _tradeStationRouteToLeanExchange = new();
 
     /// <summary>
+    /// Maps TradeStation update-order rejection substrings that should be treated as non-fatal warnings
+    /// (because the order is no longer modifiable) to the warning code and reason emitted to Lean.
+    /// </summary>
+    private static readonly Dictionary<string, (string Code, string Reason)> _updateOrderSoftRejects = new(StringComparer.InvariantCultureIgnoreCase)
+    {
+        ["Failed to Cancel/Replace order: Not an open order."] = ("UpdateNotOpenOrder", "the order is already closed"),
+        ["Cancel/Replace not allowed after cancel has been attempted"] = ("UpdateAfterCancelAttempted", "a cancel has already been attempted on the order"),
+    };
+
+    /// <summary>
     /// Represents a type capable of fetching the holdings for the specified symbol
     /// </summary>
     protected ISecurityProvider SecurityProvider { get; private set; }
@@ -720,9 +730,9 @@ public partial class TradeStationBrokerage : Brokerage
                 response = true;
                 _updateSubmittedResponseResultByBrokerageID[brokerageOrderId] = true;
             }
-            catch (Exception exception) when (exception.Message.Equals("Failed to Cancel/Replace order: Not an open order.", StringComparison.InvariantCultureIgnoreCase))
+            catch (Exception exception) when (_updateOrderSoftRejects.TryGetValue(exception.Message, out var softReject))
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", $"Failed to update Order: OrderId: {order.Id} (BrokerId: {brokerageOrderId}) for {order.Symbol}, the order is already closed"));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, softReject.Code, $"Failed to update Order: OrderId: {order.Id} (BrokerId: {brokerageOrderId}) for {order.Symbol}, {softReject.Reason}"));
             }
             catch (Exception exception) when (exception.Message.Contains("prior stop already triggered", StringComparison.InvariantCultureIgnoreCase))
             {

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -80,6 +80,11 @@ public partial class TradeStationBrokerage : Brokerage
     private bool _isSubscribeOnStreamOrderUpdate;
 
     /// <summary>
+    /// Indicates whether the warning for an update rejected because the order's prior stop already triggered has been fired.
+    /// </summary>
+    private volatile bool _priorStopTriggeredWarningFired;
+
+    /// <summary>
     /// Signals to a <see cref="CancellationToken"/> that it should be canceled.
     /// </summary>
     private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -718,6 +723,14 @@ public partial class TradeStationBrokerage : Brokerage
             catch (Exception exception) when (exception.Message.Equals("Failed to Cancel/Replace order: Not an open order.", StringComparison.InvariantCultureIgnoreCase))
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateNotOpenOrder", $"Failed to update Order: OrderId: {order.Id} (BrokerId: {brokerageOrderId}) for {order.Symbol}, the order is already closed"));
+            }
+            catch (Exception exception) when (exception.Message.Contains("prior stop already triggered", StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (!_priorStopTriggeredWarningFired)
+                {
+                    _priorStopTriggeredWarningFired = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdatePriorStopTriggered", $"Failed to update Order: OrderId: {order.Id} (BrokerId: {brokerageOrderId}) for {order.Symbol}, the prior stop has already triggered"));
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
#### Description
Downgrade the TradeStation `ReplaceOrder` rejection `too late: prior stop already triggered` from a fatal `BrokerageMessageType.Error` to a one-time `Warning`, mirroring the existing `Not an open order` branch.

#### Related PR(s)
N/A

#### Related Issue
closes #85

#### Motivation and Context
When a stop order is triggered between the time Lean sends an update and the moment TradeStation processes it, the API replies with `too late: prior stop already triggered`. The previous handler surfaced this as a `BrokerageMessageType.Error`, which immediately ends the live algorithm with a runtime error even though the order state is consistent and recoverable.

```
ERROR:: Brokerage.OnMessage(): Error - Code: UpdateOrderInvalid - too late: prior stop already triggered
ERROR:: Extensions.SetRuntimeError(): RuntimeError ... Brokerage Error System.Exception: too late: prior stop already triggered
```

The race is expected on stop/stop-limit orders and should not stop the algorithm.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually verified against a stop order that triggers concurrently with an `UpdateOrder` call: the brokerage now emits a single `UpdatePriorStopTriggered` warning and the algorithm keeps running.

<img width="1385" height="208" alt="image" src="https://github.com/user-attachments/assets/17a9dab3-ff71-4edc-b548-3381e716a2ea" />

<img width="1796" height="127" alt="image" src="https://github.com/user-attachments/assets/1d3e3efb-1052-4504-8797-446516bd3f6c" />


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`