### PR TITLE
fix: drop fill-carrying ACK/DON for all order types before terminal FLL (#84)

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
@@ -1021,5 +1021,190 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Assert.AreEqual(100m, filled.FillQuantity, "Filled event must carry the full fill quantity.");
             Assert.AreEqual(20.57m, filled.FillPrice, "Filled event must carry the fill price.");
         }
+
+        /// <summary>
+        /// Covers issue #84: an in-flight Lean UpdateOrder collides with a TradeStation fill, and
+        /// TradeStation streams TWO post-update ACK frames before the terminal FLL — a price-change
+        /// ACK (ExecQuantity = 0) followed by a fill-carrying ACK (ExecQuantity = 100).
+        /// <c>_skipWebSocketUpdatesForLeanOrders</c> drains only the first; the fill-carrying ACK is
+        /// then dropped by the ExecQuantity guard so the terminal FLL keeps the full fill delta.
+        /// </summary>
+        [Test]
+        public void EmitsFilledEventForLimitOrderWhenLeanUpdateCollidesWithFillFromTradeStation()
+        {
+            var orderProvider = new OrderProvider();
+            var ts = TestSetup.CreateBrokerageStub(orderProvider, default);
+
+            var capturedEvents = new List<OrderEvent>();
+            var filledEventReceived = new AutoResetEvent(false);
+
+            ts.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                capturedEvents.AddRange(orderEvents);
+                if (orderEvents.Any(e => e.Status == OrderStatus.Filled))
+                {
+                    filledEventReceived.Set();
+                }
+            };
+
+            // init flag _isSubscribeOnStreamOrderUpdate which allow use WS msg updates
+            ts.Connect();
+
+            var limitOrder = new LimitOrder(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), 100, 272m, DateTime.UtcNow);
+            limitOrder.BrokerId.Add("952173212");
+            orderProvider.Add(limitOrder);
+
+            // PlaceOrder stub: emits Submitted + seeds _skipWebSocketUpdatesForLeanOrders so Frame 1 is drained.
+            ts.PlaceOrder(limitOrder);
+
+            // Frame 1: initial post-PlaceOrder ACK (ExecQuantity = 0, LimitPrice = 272) - drained by skip marker.
+            var initialAckJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""CommissionFee"": ""0"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""GTC"",
+                ""FilledPrice"": ""0"",
+                ""GoodTillDate"": ""2026-07-23T00:00:00Z"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""0"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""100"",
+                        ""QuantityRemaining"": ""100"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""LimitPrice"": ""272"",
+                ""OpenedDateTime"": ""2026-04-24T14:43:14Z"",
+                ""OrderID"": ""952173212"",
+                ""OrderType"": ""Limit"",
+                ""PriceUsedForBuyingPower"": ""272"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""ACK"",
+                ""StatusDescription"": ""Received"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            ts.HandleTradeStationMessage(initialAckJson);
+
+            // Lean calls UpdateOrder (limit 272 -> 272.3). Stub emits UpdateSubmitted + re-seeds skip marker.
+            ts.UpdateOrder(limitOrder);
+
+            // Frame 2: post-update price-change ACK (ExecQuantity = 0, LimitPrice = 272.3).
+            // Consumes the single skip marker UpdateOrder just seeded.
+            var postUpdatePriceChangeAckJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""CommissionFee"": ""0"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""GTC"",
+                ""FilledPrice"": ""0"",
+                ""GoodTillDate"": ""2026-07-23T00:00:00Z"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""0"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""100"",
+                        ""QuantityRemaining"": ""100"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""LimitPrice"": ""272.3"",
+                ""OpenedDateTime"": ""2026-04-24T14:43:14Z"",
+                ""OrderID"": ""952173212"",
+                ""OrderType"": ""Limit"",
+                ""PriceUsedForBuyingPower"": ""272.3"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""ACK"",
+                ""StatusDescription"": ""Received"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            ts.HandleTradeStationMessage(postUpdatePriceChangeAckJson);
+
+            // Frame 3: post-update fill-carrying ACK (ExecQuantity = 100, ExecutionPrice = 272.22).
+            // Skip marker already exhausted by Frame 2; the ExecQuantity > 0 guard now drops this
+            // frame so the terminal FLL owns the fill delta (#84).
+            var postUpdateFillCarryingAckJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""CommissionFee"": ""1"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""GTC"",
+                ""FilledPrice"": ""272.22"",
+                ""GoodTillDate"": ""2026-07-23T00:00:00Z"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""100"",
+                        ""ExecutionPrice"": ""272.22"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""100"",
+                        ""QuantityRemaining"": ""0"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""LimitPrice"": ""272.3"",
+                ""OpenedDateTime"": ""2026-04-24T14:43:14Z"",
+                ""OrderID"": ""952173212"",
+                ""OrderType"": ""Limit"",
+                ""PriceUsedForBuyingPower"": ""272.3"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""ACK"",
+                ""StatusDescription"": ""Received"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            ts.HandleTradeStationMessage(postUpdateFillCarryingAckJson);
+
+            // Frame 4: FLL - terminal Filled. Same leg/exec as Frame 3.
+            var fllJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""ClosedDateTime"": ""2026-04-24T14:43:16Z"",
+                ""CommissionFee"": ""1"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""GTC"",
+                ""FilledPrice"": ""272.22"",
+                ""GoodTillDate"": ""2026-07-23T00:00:00Z"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""100"",
+                        ""ExecutionPrice"": ""272.22"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""100"",
+                        ""QuantityRemaining"": ""0"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""LimitPrice"": ""272.3"",
+                ""OpenedDateTime"": ""2026-04-24T14:43:14Z"",
+                ""OrderID"": ""952173212"",
+                ""OrderType"": ""Limit"",
+                ""PriceUsedForBuyingPower"": ""272.3"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""FLL"",
+                ""StatusDescription"": ""Filled"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            ts.HandleTradeStationMessage(fllJson);
+
+            Assert.IsTrue(filledEventReceived.WaitOne(TimeSpan.FromSeconds(1)), "Did not receive a Filled order event.");
+
+            // Expected lifecycle: Submitted (PlaceOrder stub), UpdateSubmitted (UpdateOrder stub),
+            // Filled (Frame 4 FLL). Frames 1, 2, 3 are drained by the skip marker and the ExecQuantity guard.
+            Assert.IsFalse(capturedEvents.Any(e => e.Status == OrderStatus.UpdateSubmitted && e.FillQuantity != 0),
+                "Fill-carrying post-update ACK must not be rewritten to UpdateSubmitted (#84).");
+
+            var filled = capturedEvents.SingleOrDefault(e => e.Status == OrderStatus.Filled);
+            Assert.IsNotNull(filled, "Expected a Filled event after FLL frame (#84).");
+            Assert.AreEqual(100m, filled.FillQuantity, "Filled event must carry the full fill quantity (#84).");
+            Assert.AreEqual(272.22m, filled.FillPrice, "Filled event must carry the fill price (#84).");
+        }
     }
 }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -1033,11 +1033,11 @@ public partial class TradeStationBrokerage : Brokerage
                         // to keep the Lean order lifecycle consistent.
                         if (brokerageOrder.Status is TradeStationOrderStatusType.Ack or TradeStationOrderStatusType.Don)
                         {
-                            // We skip 'ACK'/'DON' because these order types send fill data in the 'ACK' event
-                            // that will be duplicated in the final 'FLL' event.
-                            // Note: TrailingStop orders are executed as StopMarket orders in TradeStation.
-                            if (brokerageOrder.OrderType is TradeStationOrderType.StopMarket or TradeStationOrderType.StopLimit
-                                && brokerageOrder.Legs.Any(l => l.ExecQuantity > 0))
+                            // Skip any Ack/Don that already has fill data. The final FLL event
+                            // carries the same fill, so we wait for it. If we let this Ack pass,
+                            // it becomes UpdateSubmitted (which Lean does not apply to holdings)
+                            // and the later Filled event ends up with FillQuantity = 0 (#79, #84).
+                            if (brokerageOrder.Legs.Any(l => l.ExecQuantity > 0))
                             {
                                 return;
                             }


### PR DESCRIPTION
#### Description
Skip any `ACK` / `DON` stream message that already has fill data (`ExecQuantity > 0`), for every order type. The fill stays on the final `FLL` event, so `Filled` events have the right `FillQuantity` / `FillPrice` even when a Lean `UpdateOrder` is in flight at the moment of the fill.

#### Related PRs
- #81 only covered `StopMarket` / `StopLimit`. (description below)

#### Related Issue
closess #84

#### Motivation and Context
PR #81 fixed the same kind of bug for `StopMarket` / `StopLimit` only, because those were the order types we had seen. Issue #84 shows the same bug on `Limit` orders when a Lean `UpdateOrder` and a fill happen at the same time. TradeStation sends two `ACK` frames after the update:

1. A price-change `ACK` with `ExecQuantity = 0`.
2. A fill-carrying `ACK` with `ExecQuantity = 100`.

`_skipWebSocketUpdatesForLeanOrders` drops only one `ACK`. The first one uses it up, so the second `ACK` goes through. The old guard only checked stop orders, so the `Limit` `ACK` was turned into `UpdateSubmitted` with the fill on it. Lean does not apply fills from `UpdateSubmitted` events, so the 100 shares were lost. The accumulator also remembered the 100, so the final `FLL` event came out with `FillQuantity = 0`. After that `Holdings.Quantity` stays at `0`, and every close order goes out as `SELLTOOPEN` and gets rejected with:

> `EC804: Boxed positions are not permitted. To close long position, try a "Sell" order.`

Live log (option `SPY 260511P00710000`, fill 50 @ \$0.01):

```
14:56:24.1524111Z  Submit Order: (55)   New Limit  +50 SPY 260511P00710000 @ 0.01
14:56:24.2314170Z  Order 55  EventID:1  Status: Submitted
14:56:24.4473759Z  Order 55  EventID:2  Status: UpdateSubmitted  FillQuantity: 50  FillPrice: $0.01   <-- fill lost
14:56:24.4477201Z  Submit Order: (56)   New Limit  -50 SPY 260511P00710000 @ 0.02
14:56:24.5444210Z  Order 56  EventID:1  Status: Invalid  Reason: EC804: Boxed positions are not permitted...
14:56:24.6835677Z  Order 55  EventID:3  Status: Filled                                                 <-- FillQuantity = 0
```

After the fix:

```
... Status: Submitted          Quantity: 50
... Status: UpdateSubmitted    (from Lean UpdateOrder, FillQuantity = 0)
... Status: Filled             FillQuantity: 50  FillPrice: $0.01  OrderFee: 1 USD
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added a new NUnit test `EmitsFilledEventForLimitOrderWhenLeanUpdateCollidesWithFillFromTradeStation` in `TradeStationBrokerageStreamEventsTests`. It plays the four frames from the live log:

1. First `ACK` after `PlaceOrder` (`ExecQuantity = 0`) - dropped by the skip marker.
2. `UpdateOrder` - adds a new skip marker.
3. Post-update price-change `ACK` (`ExecQuantity = 0`) - uses up the skip marker.
4. Post-update fill-carrying `ACK` (`ExecQuantity = 100`) - dropped by the new guard.
5. Final `FLL` - emits `Filled` with `FillQuantity = 100` / `FillPrice = 272.22`.

The test checks that no `UpdateSubmitted` event carries a fill, and that the final `Filled` event has the full fill quantity and price.

All stream-event tests from PR #81 still pass (StopMarket, StopLimit, Limit user-edit, Limit + Lean update).

<img width="713" height="189" alt="image" src="https://github.com/user-attachments/assets/0bbe7192-5a48-4c99-a461-3e15171ab036" />


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`