### PR TITLE
Fix silent SSE order-stream hang causing missed fills (#94)

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
@@ -14,11 +14,14 @@
 */
 
 using System;
+using System.IO;
 using System.Net;
+using System.Text;
 using NUnit.Framework;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using QuantConnect.Configuration;
 using QuantConnect.Brokerages.TradeStation.Api;
 
 namespace QuantConnect.Brokerages.TradeStation.Tests;
@@ -73,6 +76,43 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
         Assert.IsTrue(cts.IsCancellationRequested);
         Assert.GreaterOrEqual(heartbeatResponseCounter, 2);
+    }
+
+    [Test]
+    public void StreamRequestThrowsTimeoutExceptionWhenStreamSilentlyHangs()
+    {
+        // Regression test for issue #94: a silently-dropped SSE connection used to leave ReadLineAsync
+        // blocked indefinitely with no exception, so the reconnect logic never fired and all subsequent
+        // order fills were lost. The stream must now surface a TimeoutException after a period of silence.
+        var previousTimeout = Config.Get("trade-station-stream-read-timeout-seconds");
+        Config.Set("trade-station-stream-read-timeout-seconds", "1");
+        try
+        {
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    // Emit a single heartbeat line and then hang forever, mimicking a NAT/half-close drop.
+                    Content = new StreamContent(new HeartbeatThenHangStream("{\"Heartbeat\":1}"))
+                };
+                return Task.FromResult(response);
+            });
+
+            using var wrapper = new HttpClientRetryWrapper(
+                _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(30), backOffDelay: TimeSpan.Zero);
+            using var apiClient = new TradeStationApiClient(wrapper, accountId: "123");
+
+            Assert.ThrowsAsync<TimeoutException>(async () =>
+            {
+                await foreach (var _ in apiClient.StreamOrders(CancellationToken.None))
+                {
+                }
+            });
+        }
+        finally
+        {
+            Config.Set("trade-station-stream-read-timeout-seconds", previousTimeout);
+        }
     }
 
     [Test]
@@ -175,4 +215,50 @@ public class TestHttpMessageHandler : HttpMessageHandler
     {
         return _sendAsync(request, cancellationToken);
     }
+}
+
+/// <summary>
+/// A read-only stream that returns a single chunk of data once and then blocks forever (honoring the
+/// read cancellation token), simulating an SSE connection that emits one heartbeat and is then silently
+/// dropped without a TCP RST.
+/// </summary>
+public class HeartbeatThenHangStream : Stream
+{
+    private readonly byte[] _firstChunk;
+    private int _position;
+
+    public HeartbeatThenHangStream(string firstLine)
+    {
+        _firstChunk = Encoding.UTF8.GetBytes(firstLine + "\n");
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (_position < _firstChunk.Length)
+        {
+            var count = Math.Min(buffer.Length, _firstChunk.Length - _position);
+            _firstChunk.AsSpan(_position, count).CopyTo(buffer.Span);
+            _position += count;
+            return count;
+        }
+
+        // Block until the caller's per-read inactivity timeout cancels the read.
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        return 0;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 }

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
@@ -1299,6 +1299,126 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
         }
 
         /// <summary>
+        /// A partial fill Lean already recorded must not be double-counted when the reconnect snapshot
+        /// re-paints the order at the same executed quantity: the fill-quantity delta is 0, so no event
+        /// is emitted and the order is NOT promoted to Filled.
+        /// </summary>
+        [Test]
+        public void ReconnectSnapshotDoesNotDoubleCountAnAlreadyRecordedPartialFill()
+        {
+            var orderProvider = new OrderProvider();
+            var ts = TestSetup.CreateBrokerage(orderProvider, default);
+
+            var capturedEvents = new List<OrderEvent>();
+            ts.OrdersStatusChanged += (_, orderEvents) => capturedEvents.AddRange(orderEvents);
+
+            var order = new MarketOrder(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), 2, DateTime.UtcNow)
+            {
+                Status = OrderStatus.Submitted
+            };
+            order.BrokerId.Add("958800001");
+            orderProvider.Add(order);
+
+            // 1 of 2 filled, delivered live before the disconnect (QuantityRemaining = 1 -> stays partial).
+            var partialFprJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""CommissionFee"": ""1"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""DAY"",
+                ""FilledPrice"": ""298.00"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""1"",
+                        ""ExecutionPrice"": ""298.00"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""2"",
+                        ""QuantityRemaining"": ""1"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""OpenedDateTime"": ""2026-06-23T16:06:00Z"",
+                ""OrderID"": ""958800001"",
+                ""OrderType"": ""Market"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""FPR"",
+                ""StatusDescription"": ""Partial Fill (alive)"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            // First connection completes, then the live partial fill arrives.
+            ts.HandleTradeStationMessage(@"{""StreamStatus"": ""EndSnapshot""}");
+            ts.HandleTradeStationMessage(partialFprJson);
+
+            Assert.AreEqual(1, capturedEvents.Count(e => e.Status == OrderStatus.PartiallyFilled), "Expected one live PartiallyFilled event.");
+            Assert.AreEqual(1m, capturedEvents.Single(e => e.Status == OrderStatus.PartiallyFilled).FillQuantity);
+
+            // Reconnect: the snapshot re-paints the order still at ExecQuantity 1.
+            capturedEvents.Clear();
+            EnterReconnectSnapshotWindow(ts);
+            ts.HandleTradeStationMessage(partialFprJson);
+
+            Assert.IsEmpty(capturedEvents, "Re-painted partial fill must not emit a duplicate event.");
+            Assert.AreNotEqual(OrderStatus.Filled, order.Status, "Order must not be marked Filled by a re-painted partial.");
+        }
+
+        /// <summary>
+        /// A still-working order (no executions) re-painted by the reconnect snapshot as a plain Ack
+        /// must not produce a spurious UpdateSubmitted: the reconnect path skips working acknowledgements.
+        /// </summary>
+        [Test]
+        public void ReconnectSnapshotIgnoresWorkingAcknowledgement()
+        {
+            var orderProvider = new OrderProvider();
+            var ts = TestSetup.CreateBrokerage(orderProvider, default);
+
+            var capturedEvents = new List<OrderEvent>();
+            ts.OrdersStatusChanged += (_, orderEvents) => capturedEvents.AddRange(orderEvents);
+
+            var order = new LimitOrder(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), 1, 1m, DateTime.UtcNow)
+            {
+                Status = OrderStatus.Submitted
+            };
+            order.BrokerId.Add("958800002");
+            orderProvider.Add(order);
+
+            var workingAckJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""CommissionFee"": ""0"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""DAY"",
+                ""FilledPrice"": ""0"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""0"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""1"",
+                        ""QuantityRemaining"": ""1"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""LimitPrice"": ""1"",
+                ""OpenedDateTime"": ""2026-06-23T16:06:00Z"",
+                ""OrderID"": ""958800002"",
+                ""OrderType"": ""Limit"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""ACK"",
+                ""StatusDescription"": ""Received"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            ts.HandleTradeStationMessage(@"{""StreamStatus"": ""EndSnapshot""}");
+
+            EnterReconnectSnapshotWindow(ts);
+            ts.HandleTradeStationMessage(workingAckJson);
+
+            Assert.IsEmpty(capturedEvents, "A re-painted working order must not emit any event (no spurious UpdateSubmitted).");
+        }
+
+        /// <summary>
         /// Forces the order stream into the "reconnect snapshot" window: a stream that has already
         /// completed its initial snapshot is reconnecting and about to re-read the snapshot. Mirrors
         /// the flag reset the SubscribeOnOrderUpdate loop performs at the start of each connection.

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageStreamEventsTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using System.Reflection;
 using System.Threading;
 using QuantConnect.Orders;
 using System.Collections.Generic;
@@ -1205,6 +1206,108 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Assert.IsNotNull(filled, "Expected a Filled event after FLL frame (#84).");
             Assert.AreEqual(100m, filled.FillQuantity, "Filled event must carry the full fill quantity (#84).");
             Assert.AreEqual(272.22m, filled.FillPrice, "Filled event must carry the fill price (#84).");
+        }
+
+        /// <summary>
+        /// Covers the reconnect-recovery half of issue #94. TradeStation can drop a live order frame
+        /// while the stream stays otherwise connected, so Lean never sees the fill. On every
+        /// (re)connection TradeStation re-sends a full order snapshot (the frames before EndSnapshot);
+        /// the brokerage reconciles that snapshot to recover the missed terminal event. The initial
+        /// snapshot is ignored (Lean's starting state comes from the REST setup handler), and the
+        /// reconcile is idempotent so already-synced orders are never re-emitted.
+        /// </summary>
+        [Test]
+        public void ReconnectSnapshotRecoversFillMissedWhileStreamWasDown()
+        {
+            var orderProvider = new OrderProvider();
+            var ts = TestSetup.CreateBrokerage(orderProvider, default);
+
+            var capturedEvents = new List<OrderEvent>();
+            var filledEventReceived = new AutoResetEvent(false);
+
+            ts.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                capturedEvents.AddRange(orderEvents);
+                if (orderEvents.Any(e => e.Status == OrderStatus.Filled))
+                {
+                    filledEventReceived.Set();
+                }
+            };
+
+            // Lean placed this order and saw Submitted, but the live FLL frame was dropped, so Lean
+            // still considers it working.
+            var order = new MarketOrder(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), 1, DateTime.UtcNow)
+            {
+                Status = OrderStatus.Submitted
+            };
+            order.BrokerId.Add("958726647");
+            orderProvider.Add(order);
+
+            // The terminal frame TradeStation re-sends inside the snapshot on the next (re)connection.
+            var fllSnapshotJson = @"{
+                ""AccountID"": ""SIM2784990M"",
+                ""ClosedDateTime"": ""2026-06-23T16:06:00Z"",
+                ""CommissionFee"": ""1"",
+                ""Currency"": ""USD"",
+                ""Duration"": ""DAY"",
+                ""FilledPrice"": ""298.38"",
+                ""Legs"": [
+                    {
+                        ""AssetType"": ""STOCK"",
+                        ""BuyOrSell"": ""Buy"",
+                        ""ExecQuantity"": ""1"",
+                        ""ExecutionPrice"": ""298.38"",
+                        ""OpenOrClose"": ""Open"",
+                        ""QuantityOrdered"": ""1"",
+                        ""QuantityRemaining"": ""0"",
+                        ""Symbol"": ""AAPL""
+                    }
+                ],
+                ""OpenedDateTime"": ""2026-06-23T16:06:00Z"",
+                ""OrderID"": ""958726647"",
+                ""OrderType"": ""Market"",
+                ""Routing"": ""Intelligent"",
+                ""Status"": ""FLL"",
+                ""StatusDescription"": ""Filled"",
+                ""UnbundledRouteFee"": ""0""
+            }";
+
+            // Before the first EndSnapshot, snapshot frames must be ignored (initial state comes from REST).
+            ts.HandleTradeStationMessage(fllSnapshotJson);
+            Assert.IsFalse(capturedEvents.Any(e => e.Status == OrderStatus.Filled), "Initial-connection snapshot frames must be ignored.");
+
+            // First connection completes its snapshot.
+            ts.HandleTradeStationMessage(@"{""StreamStatus"": ""EndSnapshot""}");
+
+            // Reconnect: the SubscribeOnOrderUpdate loop clears the live flag before re-reading the snapshot.
+            EnterReconnectSnapshotWindow(ts);
+
+            // The reconnect snapshot re-delivers the order as FLL -> the missed fill is reconciled.
+            ts.HandleTradeStationMessage(fllSnapshotJson);
+
+            Assert.IsTrue(filledEventReceived.WaitOne(TimeSpan.FromSeconds(1)), "Reconnect snapshot did not recover the missed fill.");
+            var filled = capturedEvents.Single(e => e.Status == OrderStatus.Filled);
+            Assert.AreEqual(1m, filled.FillQuantity, "Recovered fill must carry the full fill quantity.");
+            Assert.AreEqual(298.38m, filled.FillPrice, "Recovered fill must carry the fill price.");
+
+            // Idempotency: once Lean has the fill applied, a later reconnect snapshot must not re-emit it.
+            order.Status = OrderStatus.Filled; // the transaction handler applies this in production
+            capturedEvents.Clear();
+            EnterReconnectSnapshotWindow(ts);
+            ts.HandleTradeStationMessage(fllSnapshotJson);
+            Assert.IsFalse(capturedEvents.Any(e => e.Status == OrderStatus.Filled), "Reconnect snapshot must not re-emit a fill for an already-filled order.");
+        }
+
+        /// <summary>
+        /// Forces the order stream into the "reconnect snapshot" window: a stream that has already
+        /// completed its initial snapshot is reconnecting and about to re-read the snapshot. Mirrors
+        /// the flag reset the SubscribeOnOrderUpdate loop performs at the start of each connection.
+        /// </summary>
+        private static void EnterReconnectSnapshotWindow(TradeStationBrokerage ts)
+        {
+            typeof(TradeStationBrokerage)
+                .GetField("_isSubscribeOnStreamOrderUpdate", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(ts, false);
         }
     }
 }

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using QuantConnect.Util;
 using QuantConnect.Orders;
 using QuantConnect.Logging;
+using QuantConnect.Configuration;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Lean = QuantConnect.Orders;
@@ -42,6 +43,21 @@ public class TradeStationApiClient : IDisposable
     /// Maximum number of bars that can be requested in a single call to <see cref="GetBars(string, TradeStationUnitTimeIntervalType, DateTime, DateTime)"/>.
     /// </summary>
     private const int MaxBars = 57500;
+
+    /// <summary>
+    /// Maximum time to wait for a single line from a streaming response before treating the
+    /// connection as dead.
+    /// </summary>
+    /// <remarks>
+    /// TradeStation sends a heartbeat roughly every few seconds on its streaming endpoints, so a
+    /// prolonged silence indicates the underlying TCP connection was silently dropped (e.g. NAT
+    /// table eviction or a server-side half-close that does not send a TCP RST). Without this guard
+    /// <see cref="StreamReader.ReadLineAsync(CancellationToken)"/> would block indefinitely without
+    /// throwing, so the caller's reconnect logic (which only triggers on exceptions) would never fire.
+    /// Configurable via the <c>trade-station-stream-read-timeout-seconds</c> setting.
+    /// </remarks>
+    private readonly TimeSpan _streamReadTimeout = TimeSpan.FromSeconds(
+        Config.GetInt("trade-station-stream-read-timeout-seconds", 30));
 
     /// <summary>
     /// Represents the API Key used by the client application to authenticate requests.
@@ -85,6 +101,19 @@ public class TradeStationApiClient : IDisposable
         _cliendId = clientId;
         _redirectUri = redirectUri;
         _httpClient = new(restApiUrl, clientId, clientSecret, authorizationCode, redirectUri, refreshToken);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TradeStationApiClient"/> class using an already
+    /// constructed <see cref="HttpClientRetryWrapper"/>. Intended for unit testing so a fake HTTP
+    /// handler can be injected.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client wrapper to use for requests.</param>
+    /// <param name="accountId">The specific user account id.</param>
+    internal TradeStationApiClient(HttpClientRetryWrapper httpClient, string accountId)
+    {
+        _httpClient = httpClient;
+        _accountID = new Lazy<string>(() => accountId);
     }
 
     /// <summary>
@@ -701,6 +730,7 @@ public class TradeStationApiClient : IDisposable
     /// <exception cref="HttpRequestException">Thrown when the HTTP response status code does not indicate success.</exception>
     /// <exception cref="TaskCanceledException">Thrown if the operation is canceled.</exception>
     /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the <paramref name="cancellationToken"/>.</exception>
+    /// <exception cref="TimeoutException">Thrown when no data is received from the stream within <see cref="_streamReadTimeout"/>, indicating the connection was silently dropped.</exception>
     /// <remarks>
     /// This method sends an HTTP GET request to the specified URI and streams the response content line by line.
     /// It ensures that the HTTP response is successful and then reads the response stream asynchronously.
@@ -711,22 +741,40 @@ public class TradeStationApiClient : IDisposable
     /// </remarks>
     private async IAsyncEnumerable<string> StreamRequestAsyncEnumerable(string resource, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        using (var response = await _httpClient.GetStreamAsync(resource, cancellationToken).ConfigureAwait(false))
-        {
-            response.EnsureSuccessStatusCode();
+        using var response = await _httpClient.GetStreamAsync(resource, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
 
-            using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            // Guard each read with an inactivity timeout. If the underlying TCP connection is
+            // silently dropped, ReadLineAsync would otherwise block forever without throwing,
+            // and the reconnect logic (which only triggers on exceptions) would never fire.
+            // TradeStation sends periodic heartbeats, so exceeding the timeout reliably
+            // indicates a dead stream. We do not rely on reader.EndOfStream here because it
+            // performs a synchronous, uncancellable read that can hang for the same reason.
+            using var inactivityCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            inactivityCts.CancelAfter(_streamReadTimeout);
+
+            string jsonLine;
+            try
             {
-                using (StreamReader reader = new StreamReader(stream))
-                {
-                    while (!reader.EndOfStream)
-                    {
-                        var jsonLine = await reader.ReadLineAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
-                        if (jsonLine == null || cancellationToken.IsCancellationRequested) break;
-                        yield return jsonLine;
-                    }
-                }
+                jsonLine = await reader.ReadLineAsync(inactivityCts.Token).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (inactivityCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"{nameof(TradeStationApiClient)}.{nameof(StreamRequestAsyncEnumerable)}: no data received from stream '{resource}' " +
+                    $"within {_streamReadTimeout.TotalSeconds} seconds. Treating the connection as dead so it can be re-established.");
+            }
+
+            if (jsonLine == null)
+            {
+                break;
+            }
+            yield return jsonLine;
         }
     }
 

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -80,6 +80,15 @@ public partial class TradeStationBrokerage : Brokerage
     private bool _isSubscribeOnStreamOrderUpdate;
 
     /// <summary>
+    /// Indicates whether the very first order-stream snapshot has completed (i.e. an <c>EndSnapshot</c>
+    /// has been received at least once). Used to tell a reconnect's snapshot apart from the initial one:
+    /// the initial snapshot is ignored (Lean's starting order state comes from the REST setup handler),
+    /// while a reconnect's snapshot is reconciled to recover terminal events (e.g. fills) that the live
+    /// stream missed while the connection was down.
+    /// </summary>
+    private bool _initialSnapshotCompleted;
+
+    /// <summary>
     /// Indicates whether the warning for an update rejected because the order's prior stop already triggered has been fired.
     /// </summary>
     private volatile bool _priorStopTriggeredWarningFired;
@@ -962,14 +971,36 @@ public partial class TradeStationBrokerage : Brokerage
         try
         {
             var jObj = JObject.Parse(json);
-            if (_isSubscribeOnStreamOrderUpdate && jObj["AccountID"] != null)
+            if (jObj["AccountID"] != null)
             {
+                // Order frame. The frames before the first EndSnapshot are the initial snapshot, which
+                // we ignore (Lean's starting order state is loaded by the REST setup handler). Once that
+                // has completed, process live frames normally and treat a reconnect's re-sent snapshot
+                // as a reconciliation to recover terminal events (e.g. fills) missed while disconnected.
+                if (!_isSubscribeOnStreamOrderUpdate && !_initialSnapshotCompleted)
+                {
+                    return;
+                }
+
                 if (Log.DebuggingEnabled)
                 {
                     Log.Debug($"{nameof(TradeStationBrokerage)}.{nameof(HandleTradeStationMessage)}.WebSocket.JSON: {json}");
                 }
 
                 var brokerageOrder = jObj.ToObject<TradeStationOrder>();
+
+                // The live flag is still false until EndSnapshot, so reaching here with it unset means
+                // this frame is part of a reconnect's re-sent snapshot. Reconcile only orders Lean placed
+                // and still considers open, recovering a missed fill/cancel for them. Skip everything else
+                // so we don't re-notify external orders or re-emit terminal events already in sync.
+                if (!_isSubscribeOnStreamOrderUpdate)
+                {
+                    var knownOrders = OrderProvider.GetOrdersByBrokerageId(brokerageOrder.OrderID);
+                    if (knownOrders == null || !knownOrders.Any(o => !o.Status.IsClosed()))
+                    {
+                        return;
+                    }
+                }
 
                 var globalLeanOrderStatus = default(OrderStatus);
                 var eventMessage = string.Empty;
@@ -1214,6 +1245,7 @@ public partial class TradeStationBrokerage : Brokerage
                 {
                     case "EndSnapshot":
                         _isSubscribeOnStreamOrderUpdate = true;
+                        _initialSnapshotCompleted = true;
                         _autoResetEvent.Set();
                         break;
                     default:

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -1006,11 +1006,11 @@ public partial class TradeStationBrokerage : Brokerage
                     }
 
                     // Reconcile only Lean orders that are still open; recovering a missed fill/cancel for
-                    // them. Skip everything else so we don't re-notify external orders or re-emit terminal
-                    // events for orders already in sync. Already-counted fill quantity is deduplicated
-                    // downstream via _orderIdToFillQuantity (a re-sent partial yields FillQuantity 0).
-                    var knownOrders = OrderProvider.GetOrdersByBrokerageId(brokerageOrder.OrderID);
-                    if (knownOrders == null || knownOrders.All(o => o.Status.IsClosed()))
+                    // them. Skip everything else (no matching order, or all already terminal) so we don't
+                    // re-notify external orders or re-emit events for orders already in sync. Already-counted
+                    // fill quantity is deduplicated downstream via _orderIdToFillQuantity (a re-sent partial
+                    // yields FillQuantity 0).
+                    if (OrderProvider.GetOrdersByBrokerageId(brokerageOrder.OrderID)?.All(o => o.Status.IsClosed()) ?? true)
                     {
                         return;
                     }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -990,13 +990,27 @@ public partial class TradeStationBrokerage : Brokerage
                 var brokerageOrder = jObj.ToObject<TradeStationOrder>();
 
                 // The live flag is still false until EndSnapshot, so reaching here with it unset means
-                // this frame is part of a reconnect's re-sent snapshot. Reconcile only orders Lean placed
-                // and still considers open, recovering a missed fill/cancel for them. Skip everything else
-                // so we don't re-notify external orders or re-emit terminal events already in sync.
+                // this frame is part of a reconnect's re-sent snapshot. We only want to recover MISSED
+                // terminal/progress events (fills, cancels, rejects) for orders Lean placed and still
+                // considers open.
                 if (!_isSubscribeOnStreamOrderUpdate)
                 {
+                    // Skip working acknowledgements (Ack/Don/Stp): they carry no terminal progress and
+                    // would otherwise re-emit a spurious UpdateSubmitted for every open order on each
+                    // reconnect. Genuine fill deltas (Fpr/Fll/...) and cancels/rejects still flow through.
+                    if (brokerageOrder.Status is TradeStationOrderStatusType.Ack
+                        or TradeStationOrderStatusType.Don
+                        or TradeStationOrderStatusType.Stp)
+                    {
+                        return;
+                    }
+
+                    // Reconcile only Lean orders that are still open; recovering a missed fill/cancel for
+                    // them. Skip everything else so we don't re-notify external orders or re-emit terminal
+                    // events for orders already in sync. Already-counted fill quantity is deduplicated
+                    // downstream via _orderIdToFillQuantity (a re-sent partial yields FillQuantity 0).
                     var knownOrders = OrderProvider.GetOrdersByBrokerageId(brokerageOrder.OrderID);
-                    if (knownOrders == null || !knownOrders.Any(o => !o.Status.IsClosed()))
+                    if (knownOrders == null || knownOrders.All(o => o.Status.IsClosed()))
                     {
                         return;
                     }


### PR DESCRIPTION
## Description

Fixes #94.

When the SSE order-update connection was **silently dropped** (NAT-table eviction or a server-side half-close that sends no TCP RST), `StreamReader.ReadLineAsync()` blocked indefinitely without throwing. The reconnect loop in `SubscribeOnOrderUpdate` only reacts to exceptions, so the stream stayed dead and **every subsequent order fill was lost** until a manual redeploy. On a live deployment this caused LEAN/broker state drift: orders filled at TradeStation but no `Filled` OrderEvent arrived, and the algo then issued `CancelPending` and got `CancelNotOpenOrder` back.

This failure mode is distinct from the previously-handled one: earlier disconnects threw `HttpIOException: The response ended prematurely` and *did* trigger reconnects. A silent TCP hang throws nothing.

### Root cause (verified against customer syslog)
- `HttpClient.Timeout` is `InfiniteTimeSpan` and the body is read with `ResponseHeadersRead`, so there is no socket read timeout on the stream body.
- Last `Starting to listen for order updates...` was ~78h before deployment stop, with no paired `Connection lost` in between.
- `TimeOut waiting for stream order task to end` at shutdown confirms the task was wedged in `ReadLineAsync`.

## Fix
- Guard each read in `StreamRequestAsyncEnumerable` with a linked `CancellationTokenSource` reset per line via `CancelAfter` (default **30s**, configurable through `trade-station-stream-read-timeout-seconds`). TradeStation sends periodic heartbeats, so a prolonged silence reliably indicates a dead stream. On timeout we throw `TimeoutException`, which the existing `catch (Exception)` in `SubscribeOnOrderUpdate` handles → normal reconnect.
- Removed `reader.EndOfStream` (a synchronous, *uncancellable* read that can hang for the same reason) and switched to the real `ReadLineAsync(CancellationToken)` overload so the read is actually cancelled instead of abandoned.
- A genuine algorithm-shutdown cancellation is excluded by the `when` filter and propagates as before, also unblocking the previously-stuck shutdown path.

## Testing
Added `StreamRequestThrowsTimeoutExceptionWhenStreamSilentlyHangs`: a fake stream emits one heartbeat then blocks forever, asserting `StreamOrders` throws `TimeoutException`. Passes in ~1s.