### PR TITLE
Resolve cached brokerage symbols case-insensitively

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageSymbolMapperTests.cs
@@ -262,6 +262,33 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             yield return new TestCaseData("BTCZ24", Symbol.CreateFuture(Futures.Currencies.BTC, Market.CME, new DateTime(2024, 12, 27)));
         }
 
+        // Issue #96: TradeStation's streaming API occasionally delivers quote events with lowercase
+        // tickers even though GetBrokerageSymbol stored the keys in uppercase. The cached lookup must
+        // be case-insensitive so HandleQuoteEvents does not drop those quotes.
+        [TestCase("SPY", "spy", TradeStationAssetType.Stock)]
+        [TestCase("MESU26", "mesu26", TradeStationAssetType.Future)]
+        public void ResolvesCachedSymbolCaseInsensitively(string registeredBrokerageSymbol, string lowercaseBrokerageSymbol, TradeStationAssetType assetType)
+        {
+            // Sanity check: the keys really do differ only by case.
+            Assert.AreEqual(registeredBrokerageSymbol, lowercaseBrokerageSymbol.ToUpperInvariant());
+
+            Symbol registeredLeanSymbol;
+            switch (assetType)
+            {
+                case TradeStationAssetType.Future:
+                    Assert.IsTrue(_symbolMapper.TryGetLeanSymbol(registeredBrokerageSymbol, assetType, new DateTime(2026, 9, 18), out registeredLeanSymbol));
+                    break;
+                default:
+                    registeredLeanSymbol = _symbolMapper.GetLeanSymbol(registeredBrokerageSymbol, assetType.ConvertAssetTypeToSecurityType());
+                    Assert.IsNotNull(_symbolMapper.GetBrokerageSymbol(registeredLeanSymbol));
+                    break;
+            }
+
+            // The lowercase symbol delivered by the streaming API must resolve to the same Lean symbol.
+            Assert.IsTrue(_symbolMapper.TryGetLeanSymbol(lowercaseBrokerageSymbol, assetType, registeredLeanSymbol.ID.Date, out var resolvedLeanSymbol));
+            Assert.AreEqual(registeredLeanSymbol, resolvedLeanSymbol);
+        }
+
         [TestCaseSource(nameof(GetFutureSymbolsTestCases))]
         public void ConvertsFutureSymbolRoundTrip(string brokerageSymbol, Symbol leanSymbol)
         {

--- a/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationSymbolMapper.cs
@@ -37,7 +37,12 @@ public class TradeStationSymbolMapper : ISymbolMapper
     /// <summary>
     /// A concurrent dictionary that maps brokerage symbols to Lean symbols.
     /// </summary>
-    private readonly ConcurrentDictionary<string, Symbol> _leanSymbolByBrokerageSymbol = new();
+    /// <remarks>
+    /// Uses a case-insensitive comparer because TradeStation's streaming API occasionally
+    /// delivers quote events with lowercase tickers (e.g. "spy", "mesu26") even though the
+    /// keys were stored in uppercase by <see cref="GetBrokerageSymbol"/>.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, Symbol> _leanSymbolByBrokerageSymbol = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Represents a set of supported security types.


### PR DESCRIPTION
## Description

Fixes #96.

`TradeStationBrokerage.HandleQuoteEvents` was logging `Failed to map symbol '<lowercase>'` and dropping quotes whenever TradeStation's streaming API delivered tickers in lowercase (e.g. `spy`, `mesu26`). The root cause: `TradeStationSymbolMapper._leanSymbolByBrokerageSymbol` is a `ConcurrentDictionary<string, Symbol>` that used the default ordinal (case-sensitive) comparer, while `GetBrokerageSymbol` stores keys in uppercase (`"SPY"`, `"MESU26"`). The case mismatch made the cached lookup miss, and the fallback parse path also fails on lowercase input — so every affected quote event returned early, causing silent real-time data gaps during live trading.

This had no effect on order routing (orders are looked up by numeric brokerage order ID), but it stopped price/quote delivery for the affected subscriptions.

## Fix

Initialize the symbol cache with `StringComparer.OrdinalIgnoreCase`. This is the minimal change recommended in the issue — keys are stored uppercase by `GetBrokerageSymbol`, so a case-insensitive comparer lets the lookup resolve the lowercase symbols delivered by streaming events, covering all resolution paths without touching the insertion sites. Tickers are uppercase by convention in this domain, so collapsing case carries no risk of two distinct symbols colliding.

## Tests

Added `ResolvesCachedSymbolCaseInsensitively`, covering both equity (`SPY` / `spy`) and future (`MESU26` / `mesu26`): a symbol is registered uppercase, then resolved with its lowercase form and asserted to map back to the same Lean symbol. Both cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
