### PR TITLE
Add rate-limit handling (429 back-off + proactive throttling)

### DIFF
--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Linq;
 using System.Diagnostics;
 using NUnit.Framework;
 using System.Net.Http;
@@ -221,6 +222,91 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
         stopwatch.Stop();
 
         Assert.Less(stopwatch.Elapsed, TimeSpan.FromSeconds(5), "Streaming endpoints (RateLimitGroup.None) must not be rate limited.");
+    }
+
+    [Test]
+    public async Task SendAsyncRaisesRateLimitedWarningOnceUnderSustainedThrottling()
+    {
+        // Issue #98: the user must be warned once (not per request) when proactive throttling kicks in.
+        var previousQuota = Config.Get("trade-station-rate-limit-option-requests");
+        var previousWindow = Config.Get("trade-station-rate-limit-option-window-seconds");
+        Config.Set("trade-station-rate-limit-option-requests", "1");
+        Config.Set("trade-station-rate-limit-option-window-seconds", "1");
+        try
+        {
+            var handler = new TestHttpMessageHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            using var wrapper = new HttpClientRetryWrapper(
+                _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+            var warnings = 0;
+            string lastMessage = null;
+            wrapper.RateLimited += m => { Interlocked.Increment(ref warnings); lastMessage = m; };
+
+            // Quota of 1 per 1s: the 2nd and 3rd calls are throttled, but only one warning must be raised.
+            for (var i = 0; i < 3; i++)
+            {
+                await wrapper.SendAsync("/v3/marketdata/options/strikes/AAPL", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.OptionStrikes, externalCancellationToken: CancellationToken.None);
+            }
+
+            Assert.AreEqual(1, warnings, "The rate-limit warning must be raised exactly once.");
+            Assert.IsNotNull(lastMessage);
+        }
+        finally
+        {
+            RestoreConfig("trade-station-rate-limit-option-requests", previousQuota, "90");
+            RestoreConfig("trade-station-rate-limit-option-window-seconds", previousWindow, "60");
+        }
+    }
+
+    [Test]
+    public async Task SendAsyncRaisesRateLimitedWarningOn429()
+    {
+        // A 429 back-off must also surface the one-time warning.
+        var handler = new TestHttpMessageHandler((req, ct) =>
+        {
+            var rateLimited = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            rateLimited.Headers.Add("X-RateLimit-Reset", "0");
+            return Task.FromResult(rateLimited);
+        });
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 2, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        var warnings = 0;
+        wrapper.RateLimited += _ => Interlocked.Increment(ref warnings);
+
+        await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
+
+        Assert.AreEqual(1, warnings, "A 429 back-off must raise the rate-limit warning exactly once.");
+    }
+
+    [Test]
+    public async Task RateLimitedWarningIsRaisedOncePerGroup()
+    {
+        // The warning is per rate-limit group: a second hit on the same group is silent, but a different
+        // group warns again (each group has its own quota).
+        var handler = new TestHttpMessageHandler((req, ct) =>
+        {
+            var rateLimited = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            rateLimited.Headers.Add("X-RateLimit-Reset", "0");
+            return Task.FromResult(rateLimited);
+        });
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        var warnedGroups = new System.Collections.Concurrent.ConcurrentBag<string>();
+        wrapper.RateLimited += m => warnedGroups.Add(m);
+
+        await wrapper.SendAsync("/orders", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
+        await wrapper.SendAsync("/orders", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
+        await wrapper.SendAsync("/quotes", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.Quote, externalCancellationToken: CancellationToken.None);
+
+        // General (once, despite two hits) + Quote (once) = 2 warnings.
+        Assert.AreEqual(2, warnedGroups.Count, "Each rate-limit group warns once: General + Quote.");
+        Assert.IsTrue(warnedGroups.Any(m => m.Contains("General")) && warnedGroups.Any(m => m.Contains("Quote")));
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
@@ -46,7 +46,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
         using var wrapper = new HttpClientRetryWrapper(_baseUrl, handler, 5, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2));
 
-        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
 
         Assert.IsNotNull(response);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -137,7 +137,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: cts.Token);
+            await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: cts.Token);
         });
     }
 
@@ -158,7 +158,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+            await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
         });
     }
 
@@ -167,8 +167,8 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
     {
         // Proactive throttling (issue #98): a RateGate keeps requests under the documented quota. With a
         // quota of 2 per 1s window, the 3rd request must wait for the window to roll before it is sent.
-        // Uses the option endpoint because its quota window is a per-construction setting (the general and
-        // quote windows share the static 5-min back-off window, which can't be shortened at runtime).
+        // Uses the OptionStrikes group because its quota window is configurable per-construction (the general
+        // and quote windows share the static 5-min back-off window, which can't be shortened at runtime).
         var previousQuota = Config.Get("trade-station-rate-limit-option-requests");
         var previousWindow = Config.Get("trade-station-rate-limit-option-window-seconds");
         Config.Set("trade-station-rate-limit-option-requests", "2");
@@ -188,7 +188,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
             var stopwatch = Stopwatch.StartNew();
             for (var i = 0; i < 3; i++)
             {
-                await wrapper.SendAsync("/v3/marketdata/options/strikes/AAPL", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+                await wrapper.SendAsync("/v3/marketdata/options/strikes/AAPL", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.OptionStrikes, externalCancellationToken: CancellationToken.None);
             }
             stopwatch.Stop();
 
@@ -205,32 +205,22 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
     [Test]
     public async Task SendAsyncDoesNotThrottleStreamingEndpoints()
     {
-        // Streaming endpoints do not consume request quota, so even with a quota of 1 per 5min they must
-        // not be throttled. The low general quota acts as a tripwire: were a streaming request misrouted to
-        // the general gate, the 2nd call would block for the (static 5-min) window.
-        var previousQuota = Config.Get("trade-station-rate-limit-general-requests");
-        Config.Set("trade-station-rate-limit-general-requests", "1");
-        try
+        // Streaming endpoints (RateLimitGroup.None) consume no request quota and must never be throttled,
+        // no matter how many requests are made.
+        var handler = new TestHttpMessageHandler((req, ct) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < 3; i++)
         {
-            var handler = new TestHttpMessageHandler((req, ct) =>
-                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
-
-            using var wrapper = new HttpClientRetryWrapper(
-                _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
-
-            var stopwatch = Stopwatch.StartNew();
-            for (var i = 0; i < 3; i++)
-            {
-                await wrapper.SendAsync("/v3/brokerage/stream/accounts/123/orders", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
-            }
-            stopwatch.Stop();
-
-            Assert.Less(stopwatch.Elapsed, TimeSpan.FromSeconds(5), "Streaming endpoints must not be rate limited.");
+            await wrapper.SendAsync("/v3/brokerage/stream/accounts/123/orders", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.None, externalCancellationToken: CancellationToken.None);
         }
-        finally
-        {
-            RestoreConfig("trade-station-rate-limit-general-requests", previousQuota, "320");
-        }
+        stopwatch.Stop();
+
+        Assert.Less(stopwatch.Elapsed, TimeSpan.FromSeconds(5), "Streaming endpoints (RateLimitGroup.None) must not be rate limited.");
     }
 
     /// <summary>
@@ -267,7 +257,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
         using var wrapper = new HttpClientRetryWrapper(
             _baseUrl, handler, maxRetries: 3, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
 
-        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         Assert.AreEqual(2, callCount);
@@ -292,7 +282,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
         HttpResponseMessage response = null;
         Assert.DoesNotThrowAsync(async () =>
-            response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None));
+            response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None));
 
         Assert.IsNotNull(response);
         Assert.AreEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
@@ -319,7 +309,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
             _baseUrl, handler, maxRetries: 3, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
 
         var stopwatch = Stopwatch.StartNew();
-        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.General, externalCancellationToken: CancellationToken.None);
         stopwatch.Stop();
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -356,6 +346,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
                 httpMethod: HttpMethod.Get,
                 jsonBody: null,
                 retryOnTimeout: retryOnTimeout,
+                rateLimitGroup: RateLimitGroup.General,
                 externalCancellationToken: CancellationToken.None);
         });
 

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Diagnostics;
 using NUnit.Framework;
 using System.Net.Http;
 using System.Threading;
@@ -159,6 +160,170 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
         {
             await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
         });
+    }
+
+    [Test]
+    public async Task SendAsyncProactivelyThrottlesRequestsToConfiguredQuota()
+    {
+        // Proactive throttling (issue #98): a RateGate keeps requests under the documented quota. With a
+        // quota of 2 per 1s window, the 3rd request must wait for the window to roll before it is sent.
+        // Uses the option endpoint because its quota window is a per-construction setting (the general and
+        // quote windows share the static 5-min back-off window, which can't be shortened at runtime).
+        var previousQuota = Config.Get("trade-station-rate-limit-option-requests");
+        var previousWindow = Config.Get("trade-station-rate-limit-option-window-seconds");
+        Config.Set("trade-station-rate-limit-option-requests", "2");
+        Config.Set("trade-station-rate-limit-option-window-seconds", "1");
+        try
+        {
+            var callCount = 0;
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                Interlocked.Increment(ref callCount);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            using var wrapper = new HttpClientRetryWrapper(
+                _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+            var stopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < 3; i++)
+            {
+                await wrapper.SendAsync("/v3/marketdata/options/strikes/AAPL", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+            }
+            stopwatch.Stop();
+
+            Assert.AreEqual(3, callCount);
+            Assert.GreaterOrEqual(stopwatch.Elapsed, TimeSpan.FromMilliseconds(900), "The 3rd request should be throttled until the 1s quota window rolls.");
+        }
+        finally
+        {
+            RestoreConfig("trade-station-rate-limit-option-requests", previousQuota, "90");
+            RestoreConfig("trade-station-rate-limit-option-window-seconds", previousWindow, "60");
+        }
+    }
+
+    [Test]
+    public async Task SendAsyncDoesNotThrottleStreamingEndpoints()
+    {
+        // Streaming endpoints do not consume request quota, so even with a quota of 1 per 5min they must
+        // not be throttled. The low general quota acts as a tripwire: were a streaming request misrouted to
+        // the general gate, the 2nd call would block for the (static 5-min) window.
+        var previousQuota = Config.Get("trade-station-rate-limit-general-requests");
+        Config.Set("trade-station-rate-limit-general-requests", "1");
+        try
+        {
+            var handler = new TestHttpMessageHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            using var wrapper = new HttpClientRetryWrapper(
+                _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+            var stopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < 3; i++)
+            {
+                await wrapper.SendAsync("/v3/brokerage/stream/accounts/123/orders", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+            }
+            stopwatch.Stop();
+
+            Assert.Less(stopwatch.Elapsed, TimeSpan.FromSeconds(5), "Streaming endpoints must not be rate limited.");
+        }
+        finally
+        {
+            RestoreConfig("trade-station-rate-limit-general-requests", previousQuota, "320");
+        }
+    }
+
+    /// <summary>
+    /// Restores a config key after a test. <see cref="Config.Get"/> returns an empty string for an unset
+    /// key, but explicitly setting a key to "" makes it present-but-empty, which <see cref="Config.GetInt"/>
+    /// fails to parse. So when the key was previously unset we restore the production default instead.
+    /// </summary>
+    private static void RestoreConfig(string key, string previousValue, string productionDefault)
+    {
+        Config.Set(key, string.IsNullOrEmpty(previousValue) ? productionDefault : previousValue);
+    }
+
+    [Test]
+    public async Task SendAsyncRetriesOn429ThenReturnsSuccessfulResponse()
+    {
+        // Regression test for issue #98: a 429 Too Many Requests must trigger a back-off + retry rather
+        // than surface as a hard failure. Here the first call is rate limited and the retry succeeds.
+        var callCount = 0;
+        var handler = new TestHttpMessageHandler((req, ct) =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                var rateLimited = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Content = new StringContent("{\"Message\":\"Too Many Requests\"}")
+                };
+                rateLimited.Headers.Add("X-RateLimit-Reset", "0");
+                return Task.FromResult(rateLimited);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        });
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 3, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(2, callCount);
+    }
+
+    [Test]
+    public void SendAsyncRateLimitedReturns429AfterExhaustingRetriesWithoutThrowing()
+    {
+        // A persistent 429 must retry maxRetries+1 times and then return the 429 response (the caller
+        // surfaces it), rather than throwing from within the retry loop.
+        var callCount = 0;
+        var handler = new TestHttpMessageHandler((req, ct) =>
+        {
+            Interlocked.Increment(ref callCount);
+            var rateLimited = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            rateLimited.Headers.Add("X-RateLimit-Reset", "0");
+            return Task.FromResult(rateLimited);
+        });
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 2, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        HttpResponseMessage response = null;
+        Assert.DoesNotThrowAsync(async () =>
+            response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None));
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.AreEqual(3, callCount);
+    }
+
+    [Test]
+    public async Task SendAsyncHonorsXRateLimitResetBackOffDuration()
+    {
+        // The back-off before retrying a 429 must honor the X-RateLimit-Reset value (seconds until reset).
+        var callCount = 0;
+        var handler = new TestHttpMessageHandler((req, ct) =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                var rateLimited = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                rateLimited.Headers.Add("X-RateLimit-Reset", "1");
+                return Task.FromResult(rateLimited);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        using var wrapper = new HttpClientRetryWrapper(
+            _baseUrl, handler, maxRetries: 3, ctsAttemptTimeout: TimeSpan.FromSeconds(10), backOffDelay: TimeSpan.Zero);
+
+        var stopwatch = Stopwatch.StartNew();
+        var response = await wrapper.SendAsync("/resource", HttpMethod.Get, jsonBody: null, retryOnTimeout: true, externalCancellationToken: CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.GreaterOrEqual(stopwatch.Elapsed, TimeSpan.FromMilliseconds(900), "Back-off should honor the 1s X-RateLimit-Reset value.");
     }
 
     [TestCase(true, 5, 6)]

--- a/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
@@ -23,6 +23,7 @@ using QuantConnect.Logging;
 using System.Threading.Tasks;
 using QuantConnect.Configuration;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace QuantConnect.Brokerages.TradeStation.Api;
 
@@ -90,6 +91,20 @@ public class HttpClientRetryWrapper : IDisposable
             Config.GetInt("trade-station-rate-limit-option-requests", 90),
             TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-option-window-seconds", 60))),
     };
+
+    /// <summary>
+    /// The rate-limit groups for which a warning has already been raised, so <see cref="RateLimited"/> fires
+    /// at most once per group (each group has its own quota; it would otherwise be noisy under sustained
+    /// throttling).
+    /// </summary>
+    private readonly ConcurrentDictionary<RateLimitGroup, byte> _rateLimitWarned = new();
+
+    /// <summary>
+    /// Raised once, the first time a request is rate limited — either proactively throttled to stay under a
+    /// quota or backed off after a <c>429 Too Many Requests</c>. The argument is a user-facing message.
+    /// Lets the brokerage surface a one-time warning so the user knows their throughput is being constrained.
+    /// </summary>
+    public event Action<string> RateLimited;
 
     /// <summary>
     /// Initializes a new instance of <see cref="HttpClientRetryWrapper"/>.
@@ -190,6 +205,11 @@ public class HttpClientRetryWrapper : IDisposable
             // (streaming) short-circuits the condition and skips the wait.
             while (rateGate?.WaitToProceed(TimeSpan.FromMilliseconds(250)) == false)
             {
+                if (!_rateLimitWarned.ContainsKey(rateLimitGroup))
+                {
+                    WarnRateLimitedOnce(rateLimitGroup, $"Requests are being throttled to stay under TradeStation's rate limit for " +
+                        $"{rateLimitGroup} endpoints; throughput may be reduced. Consider lowering your request frequency.");
+                }
                 externalCancellationToken.ThrowIfCancellationRequested();
             }
 
@@ -231,12 +251,28 @@ public class HttpClientRetryWrapper : IDisposable
                 var retryDelay = response.GetRateLimitRetryDelay(_backOffDelay, _maxRateLimitDelay);
                 Log.Trace($"{nameof(HttpClientRetryWrapper)}.{nameof(SendAsync)}: rate limited (429) on [{requestMessage.Method.Method}]({requestMessage.RequestUri}), " +
                     $"backing off {retryDelay.TotalSeconds:F1}s before retry (attempt={attempt}/{_maxRetries}).");
+                WarnRateLimitedOnce(rateLimitGroup, $"TradeStation returned HTTP 429 (rate limit) for {rateLimitGroup} endpoints; " +
+                    "backing off and retrying automatically. Throughput may be reduced.");
                 response.Dispose();
                 await Task.Delay(retryDelay, externalCancellationToken);
                 continue;
             }
 
             return response;
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="RateLimited"/> with <paramref name="message"/> the first time it is called for the
+    /// given <paramref name="rateLimitGroup"/>, then stays silent for that group (each group has its own quota).
+    /// </summary>
+    /// <param name="rateLimitGroup">The group that was rate limited.</param>
+    /// <param name="message">The user-facing warning to surface.</param>
+    private void WarnRateLimitedOnce(RateLimitGroup rateLimitGroup, string message)
+    {
+        if (_rateLimitWarned.TryAdd(rateLimitGroup, 0))
+        {
+            RateLimited?.Invoke(message);
         }
     }
 

--- a/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
@@ -179,12 +179,19 @@ public class HttpClientRetryWrapper : IDisposable
         CancellationToken externalCancellationToken = default)
     {
         // Proactive throttle: keep this resource group under TradeStation's documented quota so we avoid
-        // tripping a 429 in the first place. Streaming endpoints (RateLimitGroup.None) consume no quota.
-        var rateGate = rateLimitGroup == RateLimitGroup.None ? null : _rateGates[rateLimitGroup];
+        // tripping a 429 in the first place. Streaming endpoints (RateLimitGroup.None) have no gate, so
+        // TryGetValue leaves rateGate null and the wait below is skipped.
+        _rateGates.TryGetValue(rateLimitGroup, out var rateGate);
 
         for (var attempt = 0; ; attempt++)
         {
-            WaitToProceed(rateGate, externalCancellationToken);
+            // Poll with a short timeout so a canceled token can abort the wait instead of blocking for the
+            // full quota window (RateGate.WaitToProceed has no cancellation-aware overload). A null gate
+            // (streaming) short-circuits the condition and skips the wait.
+            while (rateGate?.WaitToProceed(TimeSpan.FromMilliseconds(250)) == false)
+            {
+                externalCancellationToken.ThrowIfCancellationRequested();
+            }
 
             using var requestMessage = new HttpRequestMessage(httpMethod, $"{_baseUrl}{resource}");
             using var timeoutCts = new CancellationTokenSource(_ctsAttemptTimeout);
@@ -230,28 +237,6 @@ public class HttpClientRetryWrapper : IDisposable
             }
 
             return response;
-        }
-    }
-
-    /// <summary>
-    /// Blocks until the supplied <paramref name="rateGate"/> allows another request, honoring cancellation.
-    /// A <c>null</c> gate (streaming endpoints) returns immediately.
-    /// </summary>
-    /// <param name="rateGate">The throttle to wait on, or <c>null</c> to skip throttling.</param>
-    /// <param name="cancellationToken">Token used to abort the wait.</param>
-    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled while waiting.</exception>
-    private static void WaitToProceed(RateGate rateGate, CancellationToken cancellationToken)
-    {
-        if (rateGate == null)
-        {
-            return;
-        }
-
-        // Poll with a short timeout so a canceled token can abort the wait instead of blocking for the
-        // full quota window (RateGate.WaitToProceed has no cancellation-aware overload).
-        while (!rateGate.WaitToProceed(TimeSpan.FromMilliseconds(250)))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
         }
     }
 

--- a/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
@@ -14,12 +14,18 @@
 */
 
 using System;
+using System.Net;
 using System.Text;
+using System.Linq;
+using System.Buffers;
 using System.Net.Http;
 using System.Threading;
 using QuantConnect.Util;
+using System.Globalization;
 using QuantConnect.Logging;
 using System.Threading.Tasks;
+using QuantConnect.Configuration;
+using System.Collections.Concurrent;
 
 namespace QuantConnect.Brokerages.TradeStation.Api;
 
@@ -56,6 +62,41 @@ public class HttpClientRetryWrapper : IDisposable
     /// Delay between retries (back-off multiplier is applied in the loop).
     /// </summary>
     private readonly TimeSpan _backOffDelay = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// The 5-minute rolling window used both as the upper bound on a single <c>429 Too Many Requests</c>
+    /// back-off (guarding against unexpectedly large or epoch-style <c>X-RateLimit-Reset</c>/<c>Retry-After</c>
+    /// values) and as the proactive quota window for the general and quote-snapshot resource groups, which
+    /// share TradeStation's largest documented window. Defaults to 5 minutes; configurable via the
+    /// <c>trade-station-rate-limit-max-backoff-seconds</c> setting.
+    /// </summary>
+    private static readonly TimeSpan _maxRateLimitDelay = TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-max-backoff-seconds", 300));
+
+    // Proactive throttles (token buckets) keep REST traffic under TradeStation's documented quotas so a
+    // 429 is avoided in the first place. Quotas are per rolling window and configurable via the
+    // trade-station-rate-limit-* settings. Streaming endpoints do not consume request quota (no gate).
+    // See https://api.tradestation.com/docs/fundamentals/rate-limiting/.
+
+    /// <summary>
+    /// Throttles keyed by resource group. The fixed groups (general 320 / 5 min, quote 500 / 5 min) are
+    /// seeded here; per-option-endpoint gates (90 / 1 min each) are added lazily in <see cref="GetRateGate"/>
+    /// since their key is only known per request.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, RateGate> _rateGates = new()
+    {
+        ["general"] = new RateGate(Config.GetInt("trade-station-rate-limit-general-requests", 320), _maxRateLimitDelay),
+        ["quote"] = new RateGate(Config.GetInt("trade-station-rate-limit-quote-requests", 500), _maxRateLimitDelay),
+    };
+
+    /// <summary>
+    /// Number of requests allowed per <see cref="_optionWindow"/> for each individual option endpoint.
+    /// </summary>
+    private readonly int _optionQuota = Config.GetInt("trade-station-rate-limit-option-requests", 90);
+
+    /// <summary>
+    /// Rolling window for each option endpoint's request quota.
+    /// </summary>
+    private readonly TimeSpan _optionWindow = TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-option-window-seconds", 60));
 
     /// <summary>
     /// Initializes a new instance of <see cref="HttpClientRetryWrapper"/>.
@@ -142,38 +183,186 @@ public class HttpClientRetryWrapper : IDisposable
         HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead, // default in <see cref="HttpClient.DefaultCompletionOption"/>
         CancellationToken externalCancellationToken = default)
     {
+        // Proactive throttle: keep this resource group under TradeStation's documented quota so we avoid
+        // tripping a 429 in the first place. Streaming endpoints do not consume request quota (null gate).
+        var rateGate = GetRateGate(resource);
+
         for (var attempt = 0; ; attempt++)
         {
-            using (var requestMessage = new HttpRequestMessage(httpMethod, $"{_baseUrl}{resource}"))
-            {
-                using var timeoutCts = new CancellationTokenSource(_ctsAttemptTimeout);
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellationToken, timeoutCts.Token);
-                if (jsonBody != null)
-                {
-                    requestMessage.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-                }
+            WaitToProceed(rateGate, externalCancellationToken);
 
-                try
-                {
-                    return await _httpClient.SendAsync(requestMessage, httpCompletionOption, linkedCts.Token);
-                }
-                catch (TaskCanceledException tce) when (!externalCancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
-                {
-                    LogError(nameof(SendAsync), tce, requestMessage.Method.Method, requestMessage.RequestUri.ToString(), $"attempt={attempt}/{_maxRetries}");
-                    if (!retryOnTimeout || attempt >= _maxRetries)
-                    {
-                        throw;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogError(nameof(SendAsync), ex, requestMessage.Method.Method, requestMessage.RequestUri.ToString());
-                    throw;
-                }
+            using var requestMessage = new HttpRequestMessage(httpMethod, $"{_baseUrl}{resource}");
+            using var timeoutCts = new CancellationTokenSource(_ctsAttemptTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellationToken, timeoutCts.Token);
+            if (jsonBody != null)
+            {
+                requestMessage.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
             }
 
-            await Task.Delay(_backOffDelay, externalCancellationToken);
+            HttpResponseMessage response;
+            try
+            {
+                response = await _httpClient.SendAsync(requestMessage, httpCompletionOption, linkedCts.Token);
+            }
+            catch (TaskCanceledException tce) when (!externalCancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+            {
+                LogError(nameof(SendAsync), tce, requestMessage.Method.Method, requestMessage.RequestUri.ToString(), $"attempt={attempt}/{_maxRetries}");
+                if (!retryOnTimeout || attempt >= _maxRetries)
+                {
+                    throw;
+                }
+                await Task.Delay(_backOffDelay, externalCancellationToken);
+                continue;
+            }
+            catch (Exception ex)
+            {
+                LogError(nameof(SendAsync), ex, requestMessage.Method.Method, requestMessage.RequestUri.ToString());
+                throw;
+            }
+
+            // Reactive rate-limit back-off: a 429 is not a hard failure. This is a safety net behind the
+            // proactive throttle above (the per-account quota can still be tripped by other sessions, window
+            // drift, or replays). Honor the server's X-RateLimit-Reset (falling back to Retry-After, then the
+            // default back-off) and retry within the retry budget so a transient quota hit does not fail the operation.
+            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < _maxRetries)
+            {
+                var retryDelay = GetRateLimitRetryDelay(response);
+                Log.Trace($"{nameof(HttpClientRetryWrapper)}.{nameof(SendAsync)}: rate limited (429) on [{requestMessage.Method.Method}]({requestMessage.RequestUri}), " +
+                    $"backing off {retryDelay.TotalSeconds:F1}s before retry (attempt={attempt}/{_maxRetries}).");
+                response.Dispose();
+                await Task.Delay(retryDelay, externalCancellationToken);
+                continue;
+            }
+
+            return response;
         }
+    }
+
+    /// <summary>
+    /// Blocks until the supplied <paramref name="rateGate"/> allows another request, honoring cancellation.
+    /// A <c>null</c> gate (streaming endpoints) returns immediately.
+    /// </summary>
+    /// <param name="rateGate">The throttle to wait on, or <c>null</c> to skip throttling.</param>
+    /// <param name="cancellationToken">Token used to abort the wait.</param>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled while waiting.</exception>
+    private static void WaitToProceed(RateGate rateGate, CancellationToken cancellationToken)
+    {
+        if (rateGate == null)
+        {
+            return;
+        }
+
+        // Poll with a short timeout so a canceled token can abort the wait instead of blocking for the
+        // full quota window (RateGate.WaitToProceed has no cancellation-aware overload).
+        while (!rateGate.WaitToProceed(TimeSpan.FromMilliseconds(250)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the proactive throttle for the given <paramref name="resource"/> based on its TradeStation
+    /// quota group, creating it lazily. Returns <c>null</c> for streaming endpoints, which do not consume
+    /// request quota.
+    /// </summary>
+    /// <param name="resource">Relative resource path being requested.</param>
+    /// <returns>The <see cref="RateGate"/> guarding the resource's quota group, or <c>null</c> when unthrottled.</returns>
+    private RateGate GetRateGate(string resource)
+    {
+        if (resource.Contains("/stream/", StringComparison.OrdinalIgnoreCase))
+        {
+            // Streaming endpoints do not consume request quota.
+            return null;
+        }
+
+        if (resource.Contains("/marketdata/options/", StringComparison.OrdinalIgnoreCase))
+        {
+            // Each option endpoint has its own quota and its key is only known per request, so create it
+            // lazily. The static factory avoids allocating a closure on the (common) already-present path.
+            return _rateGates.GetOrAdd($"option:{GetOptionEndpointName(resource)}",
+                static (_, quota) => new RateGate(quota.Occurrences, quota.Window), (Occurrences: _optionQuota, Window: _optionWindow));
+        }
+
+        if (resource.Contains("/marketdata/quotes/", StringComparison.OrdinalIgnoreCase))
+        {
+            return _rateGates["quote"];
+        }
+
+        return _rateGates["general"];
+    }
+
+    /// <summary>
+    /// Delimiters that terminate the option endpoint segment within a resource path.
+    /// </summary>
+    private static readonly SearchValues<char> _optionEndpointDelimiters = SearchValues.Create("/?");
+
+    /// <summary>
+    /// Extracts the option endpoint name (the path segment following <c>/options/</c>) used to give each
+    /// option endpoint its own throttle.
+    /// </summary>
+    /// <param name="resource">Relative resource path containing <c>/options/</c>.</param>
+    /// <returns>The endpoint segment (e.g. <c>expirations</c> or <c>strikes</c>).</returns>
+    private static string GetOptionEndpointName(string resource)
+    {
+        const string marker = "/options/";
+        var start = resource.IndexOf(marker, StringComparison.OrdinalIgnoreCase) + marker.Length;
+        var rest = resource.AsSpan(start);
+        var end = rest.IndexOfAny(_optionEndpointDelimiters);
+        return (end >= 0 ? rest[..end] : rest).ToString();
+    }
+
+    /// <summary>
+    /// Computes how long to wait before retrying a <c>429 Too Many Requests</c> response, preferring the
+    /// <c>X-RateLimit-Reset</c> header (seconds until the quota window resets), then <c>Retry-After</c>,
+    /// then the default back-off. The result is clamped to <see cref="_maxRateLimitDelay"/>.
+    /// </summary>
+    /// <param name="response">The rate-limited HTTP response.</param>
+    /// <returns>The delay to wait before the next attempt.</returns>
+    private TimeSpan GetRateLimitRetryDelay(HttpResponseMessage response)
+    {
+        var delay = _backOffDelay;
+
+        if (TryGetSecondsHeader(response, "X-RateLimit-Reset", out var resetDelay))
+        {
+            delay = resetDelay;
+        }
+        else if (response.Headers.RetryAfter?.Delta is TimeSpan retryAfterDelta)
+        {
+            delay = retryAfterDelta;
+        }
+        else if (TryGetSecondsHeader(response, "Retry-After", out var retryAfterSeconds))
+        {
+            delay = retryAfterSeconds;
+        }
+
+        if (delay < TimeSpan.Zero)
+        {
+            delay = _backOffDelay;
+        }
+
+        return delay > _maxRateLimitDelay ? _maxRateLimitDelay : delay;
+    }
+
+    /// <summary>
+    /// Attempts to read the named response header and interpret its value as a number of seconds.
+    /// </summary>
+    /// <param name="response">The HTTP response to read from.</param>
+    /// <param name="headerName">The header name to look up.</param>
+    /// <param name="delay">The parsed delay, when the header is present and numeric.</param>
+    /// <returns><c>true</c> when the header was present and parsed; otherwise <c>false</c>.</returns>
+    private static bool TryGetSecondsHeader(HttpResponseMessage response, string headerName, out TimeSpan delay)
+    {
+        delay = default;
+        if (response.Headers.TryGetValues(headerName, out var values))
+        {
+            var raw = values.FirstOrDefault();
+            if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+            {
+                delay = TimeSpan.FromSeconds(seconds);
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>
@@ -190,10 +379,14 @@ public class HttpClientRetryWrapper : IDisposable
     }
 
     /// <summary>
-    /// Disposes the underlying <see cref="HttpClient"/>.
+    /// Disposes the underlying <see cref="HttpClient"/> and the proactive rate-limit gates.
     /// </summary>
     public void Dispose()
     {
         _httpClient?.DisposeSafely();
+        foreach (var rateGate in _rateGates.Values)
+        {
+            rateGate.DisposeSafely();
+        }
     }
 }

--- a/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/HttpClientRetryWrapper.cs
@@ -16,16 +16,13 @@
 using System;
 using System.Net;
 using System.Text;
-using System.Linq;
-using System.Buffers;
 using System.Net.Http;
 using System.Threading;
 using QuantConnect.Util;
-using System.Globalization;
 using QuantConnect.Logging;
 using System.Threading.Tasks;
 using QuantConnect.Configuration;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace QuantConnect.Brokerages.TradeStation.Api;
 
@@ -78,25 +75,21 @@ public class HttpClientRetryWrapper : IDisposable
     // See https://api.tradestation.com/docs/fundamentals/rate-limiting/.
 
     /// <summary>
-    /// Throttles keyed by resource group. The fixed groups (general 320 / 5 min, quote 500 / 5 min) are
-    /// seeded here; per-option-endpoint gates (90 / 1 min each) are added lazily in <see cref="GetRateGate"/>
-    /// since their key is only known per request.
+    /// One proactive throttle per <see cref="RateLimitGroup"/>. General (320 / 5 min) and quote
+    /// (500 / 5 min) share the static 5-minute window; each option endpoint gets its own 90 / 1 min gate.
+    /// <see cref="RateLimitGroup.None"/> (streaming) has no gate.
     /// </summary>
-    private readonly ConcurrentDictionary<string, RateGate> _rateGates = new()
+    private readonly Dictionary<RateLimitGroup, RateGate> _rateGates = new()
     {
-        ["general"] = new RateGate(Config.GetInt("trade-station-rate-limit-general-requests", 320), _maxRateLimitDelay),
-        ["quote"] = new RateGate(Config.GetInt("trade-station-rate-limit-quote-requests", 500), _maxRateLimitDelay),
+        [RateLimitGroup.General] = new RateGate(Config.GetInt("trade-station-rate-limit-general-requests", 320), _maxRateLimitDelay),
+        [RateLimitGroup.Quote] = new RateGate(Config.GetInt("trade-station-rate-limit-quote-requests", 500), _maxRateLimitDelay),
+        [RateLimitGroup.OptionExpirations] = new RateGate(
+            Config.GetInt("trade-station-rate-limit-option-requests", 90),
+            TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-option-window-seconds", 60))),
+        [RateLimitGroup.OptionStrikes] = new RateGate(
+            Config.GetInt("trade-station-rate-limit-option-requests", 90),
+            TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-option-window-seconds", 60))),
     };
-
-    /// <summary>
-    /// Number of requests allowed per <see cref="_optionWindow"/> for each individual option endpoint.
-    /// </summary>
-    private readonly int _optionQuota = Config.GetInt("trade-station-rate-limit-option-requests", 90);
-
-    /// <summary>
-    /// Rolling window for each option endpoint's request quota.
-    /// </summary>
-    private readonly TimeSpan _optionWindow = TimeSpan.FromSeconds(Config.GetInt("trade-station-rate-limit-option-window-seconds", 60));
 
     /// <summary>
     /// Initializes a new instance of <see cref="HttpClientRetryWrapper"/>.
@@ -160,7 +153,7 @@ public class HttpClientRetryWrapper : IDisposable
     /// <returns>The HTTP response message.</returns>
     public async Task<HttpResponseMessage> GetStreamAsync(string resource, CancellationToken cancellationToken)
     {
-        return await SendAsync(resource, HttpMethod.Get, jsonBody: null, retryOnTimeout: true, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        return await SendAsync(resource, HttpMethod.Get, jsonBody: null, retryOnTimeout: true, RateLimitGroup.None, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
     }
 
     /// <summary>
@@ -171,6 +164,7 @@ public class HttpClientRetryWrapper : IDisposable
     /// <param name="httpMethod">HTTP method to use (GET/POST/PUT/etc.).</param>
     /// <param name="jsonBody">Optional JSON body to send (will be serialized as UTF-8 application/json).</param>
     /// <param name="retryOnTimeout">If true, the method will retry when an attempt times out (default: true).</param>
+    /// <param name="rateLimitGroup">The TradeStation rate-limit group this request belongs to, used to select the proactive throttle.</param>
     /// <param name="httpCompletionOption">Completion option to pass to <see cref="HttpClient.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)"/>.</param>
     /// <param name="externalCancellationToken">Cancellation token to cancel the entire operation from the caller side.</param>
     /// <returns>The successful <see cref="HttpResponseMessage"/>.</returns>
@@ -180,12 +174,13 @@ public class HttpClientRetryWrapper : IDisposable
         HttpMethod httpMethod,
         string jsonBody,
         bool retryOnTimeout,
+        RateLimitGroup rateLimitGroup,
         HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead, // default in <see cref="HttpClient.DefaultCompletionOption"/>
         CancellationToken externalCancellationToken = default)
     {
         // Proactive throttle: keep this resource group under TradeStation's documented quota so we avoid
-        // tripping a 429 in the first place. Streaming endpoints do not consume request quota (null gate).
-        var rateGate = GetRateGate(resource);
+        // tripping a 429 in the first place. Streaming endpoints (RateLimitGroup.None) consume no quota.
+        var rateGate = rateLimitGroup == RateLimitGroup.None ? null : _rateGates[rateLimitGroup];
 
         for (var attempt = 0; ; attempt++)
         {
@@ -226,7 +221,7 @@ public class HttpClientRetryWrapper : IDisposable
             // default back-off) and retry within the retry budget so a transient quota hit does not fail the operation.
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < _maxRetries)
             {
-                var retryDelay = GetRateLimitRetryDelay(response);
+                var retryDelay = response.GetRateLimitRetryDelay(_backOffDelay, _maxRateLimitDelay);
                 Log.Trace($"{nameof(HttpClientRetryWrapper)}.{nameof(SendAsync)}: rate limited (429) on [{requestMessage.Method.Method}]({requestMessage.RequestUri}), " +
                     $"backing off {retryDelay.TotalSeconds:F1}s before retry (attempt={attempt}/{_maxRetries}).");
                 response.Dispose();
@@ -258,111 +253,6 @@ public class HttpClientRetryWrapper : IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
         }
-    }
-
-    /// <summary>
-    /// Resolves the proactive throttle for the given <paramref name="resource"/> based on its TradeStation
-    /// quota group, creating it lazily. Returns <c>null</c> for streaming endpoints, which do not consume
-    /// request quota.
-    /// </summary>
-    /// <param name="resource">Relative resource path being requested.</param>
-    /// <returns>The <see cref="RateGate"/> guarding the resource's quota group, or <c>null</c> when unthrottled.</returns>
-    private RateGate GetRateGate(string resource)
-    {
-        if (resource.Contains("/stream/", StringComparison.OrdinalIgnoreCase))
-        {
-            // Streaming endpoints do not consume request quota.
-            return null;
-        }
-
-        if (resource.Contains("/marketdata/options/", StringComparison.OrdinalIgnoreCase))
-        {
-            // Each option endpoint has its own quota and its key is only known per request, so create it
-            // lazily. The static factory avoids allocating a closure on the (common) already-present path.
-            return _rateGates.GetOrAdd($"option:{GetOptionEndpointName(resource)}",
-                static (_, quota) => new RateGate(quota.Occurrences, quota.Window), (Occurrences: _optionQuota, Window: _optionWindow));
-        }
-
-        if (resource.Contains("/marketdata/quotes/", StringComparison.OrdinalIgnoreCase))
-        {
-            return _rateGates["quote"];
-        }
-
-        return _rateGates["general"];
-    }
-
-    /// <summary>
-    /// Delimiters that terminate the option endpoint segment within a resource path.
-    /// </summary>
-    private static readonly SearchValues<char> _optionEndpointDelimiters = SearchValues.Create("/?");
-
-    /// <summary>
-    /// Extracts the option endpoint name (the path segment following <c>/options/</c>) used to give each
-    /// option endpoint its own throttle.
-    /// </summary>
-    /// <param name="resource">Relative resource path containing <c>/options/</c>.</param>
-    /// <returns>The endpoint segment (e.g. <c>expirations</c> or <c>strikes</c>).</returns>
-    private static string GetOptionEndpointName(string resource)
-    {
-        const string marker = "/options/";
-        var start = resource.IndexOf(marker, StringComparison.OrdinalIgnoreCase) + marker.Length;
-        var rest = resource.AsSpan(start);
-        var end = rest.IndexOfAny(_optionEndpointDelimiters);
-        return (end >= 0 ? rest[..end] : rest).ToString();
-    }
-
-    /// <summary>
-    /// Computes how long to wait before retrying a <c>429 Too Many Requests</c> response, preferring the
-    /// <c>X-RateLimit-Reset</c> header (seconds until the quota window resets), then <c>Retry-After</c>,
-    /// then the default back-off. The result is clamped to <see cref="_maxRateLimitDelay"/>.
-    /// </summary>
-    /// <param name="response">The rate-limited HTTP response.</param>
-    /// <returns>The delay to wait before the next attempt.</returns>
-    private TimeSpan GetRateLimitRetryDelay(HttpResponseMessage response)
-    {
-        var delay = _backOffDelay;
-
-        if (TryGetSecondsHeader(response, "X-RateLimit-Reset", out var resetDelay))
-        {
-            delay = resetDelay;
-        }
-        else if (response.Headers.RetryAfter?.Delta is TimeSpan retryAfterDelta)
-        {
-            delay = retryAfterDelta;
-        }
-        else if (TryGetSecondsHeader(response, "Retry-After", out var retryAfterSeconds))
-        {
-            delay = retryAfterSeconds;
-        }
-
-        if (delay < TimeSpan.Zero)
-        {
-            delay = _backOffDelay;
-        }
-
-        return delay > _maxRateLimitDelay ? _maxRateLimitDelay : delay;
-    }
-
-    /// <summary>
-    /// Attempts to read the named response header and interpret its value as a number of seconds.
-    /// </summary>
-    /// <param name="response">The HTTP response to read from.</param>
-    /// <param name="headerName">The header name to look up.</param>
-    /// <param name="delay">The parsed delay, when the header is present and numeric.</param>
-    /// <returns><c>true</c> when the header was present and parsed; otherwise <c>false</c>.</returns>
-    private static bool TryGetSecondsHeader(HttpResponseMessage response, string headerName, out TimeSpan delay)
-    {
-        delay = default;
-        if (response.Headers.TryGetValues(headerName, out var values))
-        {
-            var raw = values.FirstOrDefault();
-            if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
-            {
-                delay = TimeSpan.FromSeconds(seconds);
-                return true;
-            }
-        }
-        return false;
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage/Api/RateLimitGroup.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/RateLimitGroup.cs
@@ -1,0 +1,49 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Brokerages.TradeStation.Api;
+
+/// <summary>
+/// Identifies the TradeStation rate-limit resource group a REST request belongs to. Each request passes
+/// its group explicitly so the right proactive throttle keeps it under the documented quota.
+/// See https://api.tradestation.com/docs/fundamentals/rate-limiting/.
+/// </summary>
+public enum RateLimitGroup
+{
+    /// <summary>
+    /// No throttling. Streaming endpoints do not consume request quota.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Accounts, order details/execution, balances and positions (320 requests / 5 minutes).
+    /// </summary>
+    General,
+
+    /// <summary>
+    /// Quote snapshot (500 requests / 5 minutes).
+    /// </summary>
+    Quote,
+
+    /// <summary>
+    /// The option expirations endpoint (90 requests / 1 minute, per option endpoint).
+    /// </summary>
+    OptionExpirations,
+
+    /// <summary>
+    /// The option strikes endpoint (90 requests / 1 minute, per option endpoint).
+    /// </summary>
+    OptionStrikes,
+}

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -196,7 +196,7 @@ public class TradeStationApiClient : IDisposable
     /// </param>
     public async Task<bool> CancelOrder(string orderID)
     {
-        await RequestAsync<TradeStationAccount>($"/v3/orderexecution/orders/{orderID}", HttpMethod.Delete);
+        await RequestAsync<TradeStationAccount>($"/v3/orderexecution/orders/{orderID}", HttpMethod.Delete, RateLimitGroup.General);
         return true;
     }
 
@@ -280,7 +280,7 @@ public class TradeStationApiClient : IDisposable
         }
 
         return await RequestAsync<TradeStationPlaceOrderResponse>("/v3/orderexecution/orders", HttpMethod.Post,
-            JsonConvert.SerializeObject(tradeStationOrder, jsonSerializerSettings), retryOnTimeout: false
+            RateLimitGroup.General, JsonConvert.SerializeObject(tradeStationOrder, jsonSerializerSettings), retryOnTimeout: false
         );
     }
 
@@ -327,7 +327,7 @@ public class TradeStationApiClient : IDisposable
 
 
         var result = await RequestAsync<Models.OrderResponse>($"/v3/orderexecution/orders/{brokerId}", HttpMethod.Put,
-            JsonConvert.SerializeObject(tradeStationOrder, jsonSerializerSettings));
+            RateLimitGroup.General, JsonConvert.SerializeObject(tradeStationOrder, jsonSerializerSettings));
 
         if (result.Error != null)
         {
@@ -392,7 +392,7 @@ public class TradeStationApiClient : IDisposable
 
     public async Task<TradeStationQuoteSnapshot> GetQuoteSnapshot(string ticker)
     {
-        return await RequestAsync<TradeStationQuoteSnapshot>($"/v3/marketdata/quotes/{ticker}", HttpMethod.Get);
+        return await RequestAsync<TradeStationQuoteSnapshot>($"/v3/marketdata/quotes/{ticker}", HttpMethod.Get, RateLimitGroup.Quote);
     }
 
     /// <summary>
@@ -499,7 +499,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     public async Task<TradeStationRoute> GetRoutes()
     {
-        return await RequestAsync<TradeStationRoute>("/v3/orderexecution/routes", HttpMethod.Get);
+        return await RequestAsync<TradeStationRoute>("/v3/orderexecution/routes", HttpMethod.Get, RateLimitGroup.General);
     }
 
     /// <summary>
@@ -532,7 +532,7 @@ public class TradeStationApiClient : IDisposable
         var bars = default(IEnumerable<TradeStationBar>);
         try
         {
-            var result = await RequestAsync<TradeStationBars>(url.ToString(), HttpMethod.Get);
+            var result = await RequestAsync<TradeStationBars>(url.ToString(), HttpMethod.Get, RateLimitGroup.General);
 
             if (!string.IsNullOrEmpty(result.Error))
             {
@@ -562,7 +562,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     private async Task<TradeStationOptionExpiration> GetOptionExpirations(string ticker)
     {
-        return await RequestAsync<TradeStationOptionExpiration>($"/v3/marketdata/options/expirations/{ticker}", HttpMethod.Get);
+        return await RequestAsync<TradeStationOptionExpiration>($"/v3/marketdata/options/expirations/{ticker}", HttpMethod.Get, RateLimitGroup.OptionExpirations);
     }
 
     /// <summary>
@@ -575,7 +575,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     private async Task<TradeStationOptionStrike> GetOptionStrikes(string underlying, DateTime expirationDate)
     {
-        return await RequestAsync<TradeStationOptionStrike>($"/v3/marketdata/options/strikes/{underlying}?expiration={expirationDate.ToStringInvariant("MM-dd-yyyy")}", HttpMethod.Get);
+        return await RequestAsync<TradeStationOptionStrike>($"/v3/marketdata/options/strikes/{underlying}?expiration={expirationDate.ToStringInvariant("MM-dd-yyyy")}", HttpMethod.Get, RateLimitGroup.OptionStrikes);
     }
 
     /// <summary>
@@ -587,7 +587,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     private async Task<TradeStationOrderResponse> GetOrdersByAccountID(string accountID)
     {
-        return await RequestAsync<TradeStationOrderResponse>($"/v3/brokerage/accounts/{accountID}/orders", HttpMethod.Get);
+        return await RequestAsync<TradeStationOrderResponse>($"/v3/brokerage/accounts/{accountID}/orders", HttpMethod.Get, RateLimitGroup.General);
     }
 
     /// <summary>
@@ -597,7 +597,7 @@ public class TradeStationApiClient : IDisposable
     /// <returns></returns>
     private async Task<TradeStationPosition> GetPositions(string accountID)
     {
-        return await RequestAsync<TradeStationPosition>($"/v3/brokerage/accounts/{accountID}/positions", HttpMethod.Get);
+        return await RequestAsync<TradeStationPosition>($"/v3/brokerage/accounts/{accountID}/positions", HttpMethod.Get, RateLimitGroup.General);
     }
 
     /// <summary>
@@ -631,7 +631,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     private async Task<IEnumerable<Account>> GetAccounts()
     {
-        return (await RequestAsync<TradeStationAccount>("/v3/brokerage/accounts", HttpMethod.Get)).Accounts;
+        return (await RequestAsync<TradeStationAccount>("/v3/brokerage/accounts", HttpMethod.Get, RateLimitGroup.General)).Accounts;
     }
 
     /// <summary>
@@ -643,7 +643,7 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     private async Task<TradeStationBalance> GetBalanceByID(string accountID)
     {
-        return await RequestAsync<TradeStationBalance>($"/v3/brokerage/accounts/{accountID}/balances", HttpMethod.Get);
+        return await RequestAsync<TradeStationBalance>($"/v3/brokerage/accounts/{accountID}/balances", HttpMethod.Get, RateLimitGroup.General);
     }
 
     /// <summary>
@@ -672,6 +672,7 @@ public class TradeStationApiClient : IDisposable
     /// <typeparam name="T">The type to deserialize the response content to.</typeparam>
     /// <param name="resource">The resource path of the request relative to the base URL.</param>
     /// <param name="httpMethod">The HTTP method of the request.</param>
+    /// <param name="rateLimitGroup">The TradeStation rate-limit group this request belongs to (for proactive throttling).</param>
     /// <param name="jsonBody">Optional. The JSON body of the request.</param>
     /// <param name="retryOnTimeout">If true, the method will retry when an attempt times out (default: true).</param>
     /// <returns>
@@ -679,9 +680,9 @@ public class TradeStationApiClient : IDisposable
     /// </returns>
     /// <exception cref="JsonException">Thrown when the JSON deserialization fails.</exception>
     /// <exception cref="Exception">Thrown when an unexpected error occurs.</exception>
-    private async Task<T> RequestAsync<T>(string resource, HttpMethod httpMethod, string jsonBody = null, bool retryOnTimeout = true)
+    private async Task<T> RequestAsync<T>(string resource, HttpMethod httpMethod, RateLimitGroup rateLimitGroup, string jsonBody = null, bool retryOnTimeout = true)
     {
-        using var responseMessage = await _httpClient.SendAsync(resource, httpMethod, jsonBody, retryOnTimeout);
+        using var responseMessage = await _httpClient.SendAsync(resource, httpMethod, jsonBody, retryOnTimeout, rateLimitGroup);
 
         if (!responseMessage.IsSuccessStatusCode)
         {

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -88,6 +88,16 @@ public class TradeStationApiClient : IDisposable
     private readonly HttpClientRetryWrapper _httpClient;
 
     /// <summary>
+    /// Raised once, the first time a request is rate limited (proactively throttled or backed off after a
+    /// <c>429</c>). Forwards <see cref="HttpClientRetryWrapper.RateLimited"/> so the brokerage can warn the user.
+    /// </summary>
+    internal event Action<string> RateLimited
+    {
+        add => _httpClient.RateLimited += value;
+        remove => _httpClient.RateLimited -= value;
+    }
+
+    /// <summary>
     /// Initializes a new instance of the TradeStationApiClient class
     /// </summary>
     /// <param name="clientId">The API Key used by the client application to authenticate requests.</param>

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -325,6 +325,9 @@ public partial class TradeStationBrokerage : Brokerage
             Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(Initialize)}: AccountID: {accountId} - AccountType: {_tradeStationAccountType}");
         }
 
+        // Surface a one-time warning to the algorithm when requests start getting rate limited.
+        _tradeStationApiClient.RateLimited += OnRateLimited;
+
         _priceMapper = new PriceMapper();
         _messageHandler = new(HandleTradeStationMessage, ConcurrencyEnabled);
 
@@ -902,6 +905,13 @@ public partial class TradeStationBrokerage : Brokerage
     /// <param name="_">The sender of the event, typically unused in this implementation.</param>
     /// <param name="brokerageMessageEvent">The event data containing details of the brokerage message, such as type and content.</param>
     private void OnBrokerageMessageEventHandler(object _, BrokerageMessageEvent brokerageMessageEvent) => OnMessage(brokerageMessageEvent);
+
+    /// <summary>
+    /// Surfaces a one-time warning to the algorithm the first time the brokerage starts rate-limiting requests
+    /// (proactive throttling or a 429 back-off). Subsequent rate-limit events stay silent to avoid log spam.
+    /// </summary>
+    /// <param name="message">The user-facing warning message.</param>
+    private void OnRateLimited(string message) => OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "RateLimit", message));
 
     /// <summary>
     /// Determines if the provided <paramref name="securityType"/> matches the <see cref="TradeStationAccountType"/>.

--- a/QuantConnect.TradeStationBrokerage/TradeStationExtensions.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationExtensions.cs
@@ -14,8 +14,11 @@
 */
 
 using System;
+using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using QuantConnect.Orders;
+using System.Globalization;
 using System.Threading.Tasks;
 using QuantConnect.Securities;
 using System.Collections.Generic;
@@ -382,5 +385,62 @@ public static class TradeStationExtensions
         leanOrder.BrokerId.Add(order.OrderID);
 
         return leanOrder;
+    }
+
+    /// <summary>
+    /// Computes how long to wait before retrying a <c>429 Too Many Requests</c> response, preferring the
+    /// <c>X-RateLimit-Reset</c> header (seconds until the quota window resets), then <c>Retry-After</c>,
+    /// then <paramref name="defaultBackOff"/>. The result is clamped to <paramref name="maxDelay"/> to guard
+    /// against unexpectedly large or epoch-style header values.
+    /// </summary>
+    /// <param name="response">The rate-limited HTTP response.</param>
+    /// <param name="defaultBackOff">Fallback delay when no usable header is present.</param>
+    /// <param name="maxDelay">Upper bound on the returned delay.</param>
+    /// <returns>The delay to wait before the next attempt.</returns>
+    internal static TimeSpan GetRateLimitRetryDelay(this HttpResponseMessage response, TimeSpan defaultBackOff, TimeSpan maxDelay)
+    {
+        var delay = defaultBackOff;
+
+        if (response.TryGetSecondsFromHeader("X-RateLimit-Reset", out var resetDelay))
+        {
+            delay = resetDelay;
+        }
+        else if (response.Headers.RetryAfter?.Delta is TimeSpan retryAfterDelta)
+        {
+            delay = retryAfterDelta;
+        }
+        else if (response.TryGetSecondsFromHeader("Retry-After", out var retryAfterSeconds))
+        {
+            delay = retryAfterSeconds;
+        }
+
+        if (delay < TimeSpan.Zero)
+        {
+            delay = defaultBackOff;
+        }
+
+        return delay > maxDelay ? maxDelay : delay;
+    }
+
+    /// <summary>
+    /// Attempts to read the named response header and interpret its value as a number of seconds.
+    /// </summary>
+    /// <param name="response">The HTTP response to read from.</param>
+    /// <param name="headerName">The header name to look up.</param>
+    /// <param name="delay">The parsed delay, when the header is present and numeric.</param>
+    /// <returns><c>true</c> when the header was present and parsed; otherwise <c>false</c>.</returns>
+    private static bool TryGetSecondsFromHeader(this HttpResponseMessage response, string headerName, out TimeSpan delay)
+    {
+        delay = default;
+        if (response.Headers.TryGetValues(headerName, out var values))
+        {
+            var raw = values.FirstOrDefault();
+            if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+            {
+                delay = TimeSpan.FromSeconds(seconds);
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Implements rate-limit handling for the TradeStation REST API in `HttpClientRetryWrapper`, closing the gap where a `429 Too Many Requests` surfaced as a hard failure of the place/cancel/fetch operation (no back-off, no proactive throttling).

Closes #98.

### Reactive `429` back-off
On `HttpStatusCode.TooManyRequests`, honor the server's `X-RateLimit-Reset` (then `Retry-After`, then the default back-off), clamped to a max delay, and retry within the existing retry budget instead of throwing. A clamped delay guards against malformed/epoch-style header values.

### Proactive throttling (`RateGate`)
A per-resource-group `RateGate` (token bucket, `QuantConnect.Util.RateGate`) keeps REST traffic under TradeStation's documented quotas so a `429` is avoided in the first place:

| Resource group | Default quota |
|---|---|
| General (accounts / orders / balances / positions) | 320 / 5 min |
| Quote snapshot | 500 / 5 min |
| Each option endpoint | 90 / 1 min |

General and quote share the static 5‑min window; each option endpoint gets its own gate, created lazily. Streaming endpoints consume no request quota and are not throttled. `WaitToProceed` is cancellation-aware. All quotas are configurable via the `trade-station-rate-limit-*` settings.

## Tests

Unit tests in `TradeStationBrokerageHttpClientRetryWrapperTests`:
- proactive throttling paces requests to the configured quota;
- streaming endpoints are not throttled;
- `429` → retry → success without throwing;
- persistent `429` returns the `429` after exhausting retries (no throw from the loop);
- back-off honors the `X-RateLimit-Reset` duration.

## Live validation

Validated end-to-end by running the brokerage through the Lean Launcher against the TradeStation **simulator** (`https://sim-api.tradestation.com`) during regular trading hours.

**Setup.** The proactive `RateGate` is otherwise silent, so to make it observable the quota was temporarily shrunk to tiny values and a temporary `Log.Trace` was added in `WaitToProceed` that logs only when the gate actually blocks (both reverted; not part of this PR):

```jsonc
"trade-station-rate-limit-max-backoff-seconds": 30,   // = the static general/quote window
"trade-station-rate-limit-general-requests": 2        // 2 requests / 30s (deliberately tiny)
```

A throwaway live algorithm placed alternating ±1-share AAPL market orders every ~10s to drive REST load against the general resource group.

**Result.** The `RateGate` paced the **general resource group** under its single shared quota — confirmed across three distinct endpoints within one run:

```
WaitToProceed: proactively throttling [/v3/orderexecution/orders]                (order placement)
WaitToProceed: proactively throttling [/v3/brokerage/accounts/<id>/orders]       (open-orders poll)
WaitToProceed: proactively throttling [/v3/brokerage/accounts/<id>/positions]    (positions poll)
```

- Throttling was **sustained** over the run (not just a startup burst), and orders kept submitting and **filling** — i.e. pacing, not starvation.
- Streaming endpoints were correctly **not** throttled.
- At the deliberately absurd quota (2/30s) the gate occasionally held an order submission past LEAN's internal 1‑second `WaitForOrderSubmission` window (`The order request (Id=N) was not submitted within 1 second(s)`) — an artifact of the unrealistically tiny test quota; at the documented quotas it paces transparently.

The reactive `429` back-off path is impractical to trigger on the simulator and is covered by the unit tests.

<details>
<summary>Live test algorithm (<code>TradeStationGapTestAlgorithm</code>)</summary>

```csharp
using System;
using QuantConnect.Data;
using QuantConnect.Orders;

namespace QuantConnect.Algorithm.CSharp
{
    /// <summary>
    /// Throwaway live algorithm used to exercise the TradeStation brokerage REST path end-to-end
    /// (issue #98 rate-limit pacing). It places alternating +/-1 share AAPL market orders on a fixed
    /// cadence and logs every placement and order event. NOT a backtest or regression test.
    /// </summary>
    public class TradeStationGapTestAlgorithm : QCAlgorithm
    {
        private Symbol _symbol;
        private DateTime _nextOrderTimeUtc;
        private int _count;

        private const int MaxOrders = 30;
        private readonly TimeSpan _interval = TimeSpan.FromSeconds(10);

        public override void Initialize()
        {
            SetStartDate(2026, 6, 26);
            SetCash(100000);
            _symbol = AddEquity("AAPL", Resolution.Second).Symbol;
        }

        public override void OnData(Slice slice)
        {
            if (_count >= MaxOrders || UtcTime < _nextOrderTimeUtc)
            {
                return;
            }

            _nextOrderTimeUtc = UtcTime + _interval;
            var quantity = _count % 2 == 0 ? 1 : -1;
            var ticket = MarketOrder(_symbol, quantity);
            Log($"GAPTEST: placed #{_count} qty={quantity} leanId={ticket.OrderId} status={ticket.Status}");
            _count++;
        }

        public override void OnOrderEvent(OrderEvent orderEvent)
        {
            Log($"GAPTEST: OrderEvent leanId={orderEvent.OrderId} {orderEvent.Status} fillQty={orderEvent.FillQuantity} fillPx={orderEvent.FillPrice}");
        }
    }
}
```
</details>

## User-facing rate-limit warning (one-time, per group)

Rate limiting was previously invisible to the algorithm. The brokerage now raises a one-time
`BrokerageMessageType.Warning` **per `RateLimitGroup`** the first time that group is proactively throttled or
backed off after a `429` — so the user knows their throughput is being constrained. Subsequent hits on the
same group stay silent (no log spam); other groups warn independently.

Wired as `HttpClientRetryWrapper.RateLimited` → `TradeStationApiClient` (forwarded) → `TradeStationBrokerage.OnMessage(...)`.

**Verified live** against the TradeStation sim — the warning surfaces to the algorithm:

```
Brokerage.OnMessage(): Warning - Code: RateLimit - Requests are being throttled to stay under
   TradeStation's rate limit for General endpoints; throughput may be reduced. Consider lowering
   your request frequency.
```

It fired **exactly once** for the `General` group despite sustained startup throttling (a quota of 2/30s
against the accounts/balances/positions/orders polling). Unit tests cover: warns once under sustained
throttling, once on a `429`, and once-per-group (General + Quote → 2 warnings).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

