### PR TITLE
Surface market data errors as brokerage messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "files.autoSave": "afterDelay"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "files.autoSave": "afterDelay"
+}

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -75,6 +76,47 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             Assert.IsNull(res.Bars);
             Assert.That(res.Error, Is.EqualTo("Failed"));
             Assert.That(res.Message, Is.EqualTo("Not entitled to data for this symbol"));
+        }
+
+        [Test]
+        public void DeserializeStreamQuoteErrorFrame()
+        {
+            // The streaming quotes endpoint reports a per symbol failure as a regular frame carrying
+            // only the symbol and the error, and then stops sending data for that symbol.
+            var jsonResponse = @"{
+                ""Symbol"": ""VXMQ26"",
+                ""Error"": ""FAILED, NOT ENTITLED""
+            }";
+
+            var res = JsonConvert.DeserializeObject<Quote>(jsonResponse);
+
+            Assert.That(res.Symbol, Is.EqualTo("VXMQ26"));
+            Assert.That(res.Error, Is.EqualTo("FAILED, NOT ENTITLED"));
+            Assert.IsNull(res.Bid);
+            Assert.IsNull(res.Ask);
+            Assert.IsNull(res.Last);
+        }
+
+        [Test]
+        public void StreamQuoteErrorFrameRaisesBrokerageMessageOncePerSymbol()
+        {
+            using var brokerage = TestSetup.CreateBrokerage(null, null);
+
+            var messages = new List<BrokerageMessageEvent>();
+            brokerage.Message += (_, message) => messages.Add(message);
+
+            var handleQuoteEvents = typeof(TradeStationBrokerage)
+                .GetMethod("HandleQuoteEvents", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var errorQuote = new Quote { Symbol = "VXMQ26", Error = "FAILED, NOT ENTITLED" };
+
+            handleQuoteEvents.Invoke(brokerage, [errorQuote]);
+            // the stream is re-established on reconnection: the same failing symbol must not spam the user
+            handleQuoteEvents.Invoke(brokerage, [errorQuote]);
+
+            Assert.That(messages.Count, Is.EqualTo(1));
+            Assert.That(messages[0].Type, Is.EqualTo(BrokerageMessageType.Error));
+            Assert.That(messages[0].Message, Is.EqualTo("FAILED, NOT ENTITLED for this symbol: VXMQ26"));
         }
 
         [TestCase(@"{ ""Orders"":[ { ""Legs"": [ { ""BuyOrSell"": ""BUY"" } ] } ],""Errors"":[] }", TradeStationTradeActionType.Buy)]

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageAdditionalTests.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.IO;
-using System.Reflection;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -105,14 +104,11 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             var messages = new List<BrokerageMessageEvent>();
             brokerage.Message += (_, message) => messages.Add(message);
 
-            var handleQuoteEvents = typeof(TradeStationBrokerage)
-                .GetMethod("HandleQuoteEvents", BindingFlags.NonPublic | BindingFlags.Instance);
-
             var errorQuote = new Quote { Symbol = "VXMQ26", Error = "FAILED, NOT ENTITLED" };
 
-            handleQuoteEvents.Invoke(brokerage, [errorQuote]);
+            brokerage.HandleQuoteEvents(errorQuote);
             // the stream is re-established on reconnection: the same failing symbol must not spam the user
-            handleQuoteEvents.Invoke(brokerage, [errorQuote]);
+            brokerage.HandleQuoteEvents(errorQuote);
 
             Assert.That(messages.Count, Is.EqualTo(1));
             Assert.That(messages[0].Type, Is.EqualTo(BrokerageMessageType.Error));
@@ -318,7 +314,7 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
             var redirectUrl = Config.Get("trade-station-redirect-url");
 
             var tradeStationApiClient = new TradeStationApiClient(clientId, clientSecret, apiUrl, TradeStationAccountType.Margin,
-                string.Empty, redirectUrl, string.Empty);
+                string.Empty, redirectUrl, string.Empty, messageReceived: null);
 
             var signInUrl = tradeStationApiClient.GetSignInUrl();
             Assert.IsNotNull(signInUrl);
@@ -826,10 +822,11 @@ namespace QuantConnect.Brokerages.TradeStation.Tests
                 }
 
                 return new TradeStationApiClient(clientId, clientSecret, apiUrl, TradeStationExtensions.ParseAccountType(accountType), string.Empty,
-                    redirectUrl, authorizationCode);
+                    redirectUrl, authorizationCode, messageReceived: null);
             }
 
-            return new TradeStationApiClient(clientId, clientSecret, apiUrl, TradeStationExtensions.ParseAccountType(accountType), refreshToken, string.Empty, string.Empty);
+            return new TradeStationApiClient(clientId, clientSecret, apiUrl, TradeStationExtensions.ParseAccountType(accountType), refreshToken, string.Empty, string.Empty,
+                messageReceived: null);
         }
     }
 }

--- a/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
+++ b/QuantConnect.TradeStationBrokerage.Tests/TradeStationBrokerageHttpClientRetryWrapperTests.cs
@@ -100,7 +100,7 @@ public class TradeStationBrokerageHttpClientRetryWrapperTests
 
             using var wrapper = new HttpClientRetryWrapper(
                 _baseUrl, handler, maxRetries: 1, ctsAttemptTimeout: TimeSpan.FromSeconds(30), backOffDelay: TimeSpan.Zero);
-            using var apiClient = new TradeStationApiClient(wrapper, accountId: "123");
+            using var apiClient = new TradeStationApiClient(wrapper, accountId: "123", messageReceived: null);
 
             Assert.ThrowsAsync<TimeoutException>(async () =>
             {

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -40,6 +40,12 @@ namespace QuantConnect.Brokerages.TradeStation.Api;
 public class TradeStationApiClient : IDisposable
 {
     /// <summary>
+    /// Event raised when the API reports a condition the user should be aware of, such as a market
+    /// data request refused for lack of an entitlement.
+    /// </summary>
+    public event EventHandler<BrokerageMessageEvent> Message;
+
+    /// <summary>
     /// Maximum number of bars that can be requested in a single call to <see cref="GetBars(string, TradeStationUnitTimeIntervalType, DateTime, DateTime)"/>.
     /// </summary>
     private const int MaxBars = 57500;
@@ -536,7 +542,15 @@ public class TradeStationApiClient : IDisposable
 
             if (!string.IsNullOrEmpty(result.Error))
             {
-                throw new Exception($"[{result.Error}] {result.Message}");
+                // TradeStation answers with HTTP 200 and an error body when the bars cannot be served,
+                // for instance "Not entitled to data for this symbol" when the account has no market
+                // data entitlement for the symbol's exchange. Surface it so the user learns why the
+                // history request came back empty, appending the symbol the error refers to.
+                Log.Error($"{nameof(TradeStationApiClient)}.{nameof(GetBarsAsync)}: Failed to retrieve bars for symbol '{symbol}' " +
+                    $"with time interval '{unitOfTime}'. Start: {firstDate}, End: {lastDate}. [{result.Error}] {result.Message}");
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, result.Error,
+                    $"{result.Message}: {symbol}"));
+                yield break;
             }
 
             bars = result.Bars;
@@ -776,6 +790,15 @@ public class TradeStationApiClient : IDisposable
             }
             yield return jsonLine;
         }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="Message"/> event.
+    /// </summary>
+    /// <param name="brokerageMessageEvent">The message to report.</param>
+    private void OnMessage(BrokerageMessageEvent brokerageMessageEvent)
+    {
+        Message?.Invoke(this, brokerageMessageEvent);
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
+++ b/QuantConnect.TradeStationBrokerage/Api/TradeStationApiClient.cs
@@ -40,10 +40,10 @@ namespace QuantConnect.Brokerages.TradeStation.Api;
 public class TradeStationApiClient : IDisposable
 {
     /// <summary>
-    /// Event raised when the API reports a condition the user should be aware of, such as a market
-    /// data request refused for lack of an entitlement.
+    /// Raised when the API reports a condition the user should be aware of, such as a market data
+    /// request refused for lack of an entitlement.
     /// </summary>
-    public event EventHandler<BrokerageMessageEvent> Message;
+    private event EventHandler<BrokerageMessageEvent> MessageReceived;
 
     /// <summary>
     /// Maximum number of bars that can be requested in a single call to <see cref="GetBars(string, TradeStationUnitTimeIntervalType, DateTime, DateTime)"/>.
@@ -102,11 +102,14 @@ public class TradeStationApiClient : IDisposable
     /// <param name="refreshToken">The type of TradeStation account.</param>
     /// <param name="redirectUri">The URI to which the user will be redirected after authentication.</param>
     /// <param name="authorizationCode">The authorization code obtained from the URL during OAuth authentication. Default is an empty string.</param>
-    private TradeStationApiClient(string clientId, string clientSecret, string restApiUrl, string refreshToken, string redirectUri, string authorizationCode)
+    /// <param name="messageReceived">The handler notified of conditions the user should be aware of, such as a market data request refused for lack of an entitlement.</param>
+    private TradeStationApiClient(string clientId, string clientSecret, string restApiUrl, string refreshToken, string redirectUri, string authorizationCode,
+        EventHandler<BrokerageMessageEvent> messageReceived)
     {
         _cliendId = clientId;
         _redirectUri = redirectUri;
         _httpClient = new(restApiUrl, clientId, clientSecret, authorizationCode, redirectUri, refreshToken);
+        MessageReceived += messageReceived;
     }
 
     /// <summary>
@@ -116,10 +119,12 @@ public class TradeStationApiClient : IDisposable
     /// </summary>
     /// <param name="httpClient">The HTTP client wrapper to use for requests.</param>
     /// <param name="accountId">The specific user account id.</param>
-    internal TradeStationApiClient(HttpClientRetryWrapper httpClient, string accountId)
+    /// <param name="messageReceived">The handler notified of conditions the user should be aware of, such as a market data request refused for lack of an entitlement.</param>
+    internal TradeStationApiClient(HttpClientRetryWrapper httpClient, string accountId, EventHandler<BrokerageMessageEvent> messageReceived)
     {
         _httpClient = httpClient;
         _accountID = new Lazy<string>(() => accountId);
+        MessageReceived += messageReceived;
     }
 
     /// <summary>
@@ -132,9 +137,10 @@ public class TradeStationApiClient : IDisposable
     /// <param name="refreshToken">The type of TradeStation account.</param>
     /// <param name="redirectUri">The URI to which the user will be redirected after authentication.</param>
     /// <param name="authorizationCode">The authorization code obtained from the URL during OAuth authentication. Default is an empty string.</param>
+    /// <param name="messageReceived">The handler notified of conditions the user should be aware of, such as a market data request refused for lack of an entitlement.</param>
     public TradeStationApiClient(string clientId, string clientSecret, string restApiUrl, TradeStationAccountType tradeStationAccountType,
-        string refreshToken, string redirectUri, string authorizationCode)
-        : this(clientId, clientSecret, restApiUrl, refreshToken, redirectUri, authorizationCode)
+        string refreshToken, string redirectUri, string authorizationCode, EventHandler<BrokerageMessageEvent> messageReceived)
+        : this(clientId, clientSecret, restApiUrl, refreshToken, redirectUri, authorizationCode, messageReceived)
     {
         _accountID = new Lazy<string>(() =>
         {
@@ -154,8 +160,10 @@ public class TradeStationApiClient : IDisposable
     /// <param name="redirectUri">The URI to which the user will be redirected after authentication.</param>
     /// <param name="authorizationCode">The authorization code obtained from the URL during OAuth authentication. Default is an empty string.</param>
     /// <param name="accountId">The specific user account id.</param>
-    public TradeStationApiClient(string clientId, string clientSecret, string restApiUrl, string refreshToken, string redirectUri, string authorizationCode, string accountId)
-        : this(clientId, clientSecret, restApiUrl, refreshToken, redirectUri, authorizationCode)
+    /// <param name="messageReceived">The handler notified of conditions the user should be aware of, such as a market data request refused for lack of an entitlement.</param>
+    public TradeStationApiClient(string clientId, string clientSecret, string restApiUrl, string refreshToken, string redirectUri, string authorizationCode, string accountId,
+        EventHandler<BrokerageMessageEvent> messageReceived)
+        : this(clientId, clientSecret, restApiUrl, refreshToken, redirectUri, authorizationCode, messageReceived)
     {
         _accountID = new Lazy<string>(() =>
         {
@@ -542,14 +550,10 @@ public class TradeStationApiClient : IDisposable
 
             if (!string.IsNullOrEmpty(result.Error))
             {
-                // TradeStation answers with HTTP 200 and an error body when the bars cannot be served,
-                // for instance "Not entitled to data for this symbol" when the account has no market
-                // data entitlement for the symbol's exchange. Surface it so the user learns why the
-                // history request came back empty, appending the symbol the error refers to.
+                // TradeStation answers with HTTP 200 and an error body when the bars cannot be served
                 Log.Error($"{nameof(TradeStationApiClient)}.{nameof(GetBarsAsync)}: Failed to retrieve bars for symbol '{symbol}' " +
                     $"with time interval '{unitOfTime}'. Start: {firstDate}, End: {lastDate}. [{result.Error}] {result.Message}");
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, result.Error,
-                    $"{result.Message}: {symbol}"));
+                MessageReceived?.Invoke(this, new BrokerageMessageEvent(BrokerageMessageType.Error, result.Error, $"{result.Message}: {symbol}"));
                 yield break;
             }
 
@@ -790,15 +794,6 @@ public class TradeStationApiClient : IDisposable
             }
             yield return jsonLine;
         }
-    }
-
-    /// <summary>
-    /// Raises the <see cref="Message"/> event.
-    /// </summary>
-    /// <param name="brokerageMessageEvent">The message to report.</param>
-    private void OnMessage(BrokerageMessageEvent brokerageMessageEvent)
-    {
-        Message?.Invoke(this, brokerageMessageEvent);
     }
 
     /// <summary>

--- a/QuantConnect.TradeStationBrokerage/Models/TradeStationQuoteSnapshot.cs
+++ b/QuantConnect.TradeStationBrokerage/Models/TradeStationQuoteSnapshot.cs
@@ -117,6 +117,16 @@ public class Quote
     public string Symbol { get; init; }
 
     /// <summary>
+    /// The error reported by the streaming quotes endpoint for this symbol, if any.
+    /// </summary>
+    /// <remarks>
+    /// The stream reports per symbol failures as a regular frame carrying only the symbol and this
+    /// field, for example <c>{"Symbol":"VXMQ26","Error":"FAILED, NOT ENTITLED"}</c> when the account
+    /// has no market data entitlement for the symbol's exchange. No further frames are sent for it.
+    /// </remarks>
+    public string Error { get; init; }
+
+    /// <summary>
     /// Time of the last trade.
     /// </summary>
     public DateTime? TradeTime { get; init; }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
@@ -205,13 +205,11 @@ public partial class TradeStationBrokerage : IDataQueueHandler
     /// Handles incoming quote events and updates the order books accordingly.
     /// </summary>
     /// <param name="quote">The incoming quote containing bid, ask, and trade information.</param>
-    private void HandleQuoteEvents(Quote quote)
+    internal void HandleQuoteEvents(Quote quote)
     {
         if (!string.IsNullOrEmpty(quote.Error))
         {
-            // The stream reports a per symbol failure (e.g. a missing market data entitlement) as a
-            // frame carrying only the symbol and the error, and then sends nothing else for it. Without
-            // surfacing it the algorithm would silently receive no data at all for this symbol.
+            // The stream reports a per symbol failure and then sends nothing else for that symbol
             if (_symbolsMarketDataErrorReported.TryAdd(quote.Symbol, true))
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "MarketDataError",

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.DataQueueHandler.cs
@@ -59,6 +59,12 @@ public partial class TradeStationBrokerage : IDataQueueHandler
     private readonly ConcurrentDictionary<Symbol, bool> _symbolsDelayChecked = [];
 
     /// <summary>
+    /// Tracks the brokerage symbols whose market data error has already been reported, so a single
+    /// failing symbol does not raise the same message on every stream reconnection.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, bool> _symbolsMarketDataErrorReported = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Aggregates ticks and bars based on given subscriptions.
     /// </summary>
     protected IDataAggregator _aggregator;
@@ -201,6 +207,19 @@ public partial class TradeStationBrokerage : IDataQueueHandler
     /// <param name="quote">The incoming quote containing bid, ask, and trade information.</param>
     private void HandleQuoteEvents(Quote quote)
     {
+        if (!string.IsNullOrEmpty(quote.Error))
+        {
+            // The stream reports a per symbol failure (e.g. a missing market data entitlement) as a
+            // frame carrying only the symbol and the error, and then sends nothing else for it. Without
+            // surfacing it the algorithm would silently receive no data at all for this symbol.
+            if (_symbolsMarketDataErrorReported.TryAdd(quote.Symbol, true))
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "MarketDataError",
+                    $"{quote.Error} for this symbol: {quote.Symbol}"));
+            }
+            return;
+        }
+
         if (!_symbolMapper.TryGetLeanSymbol(quote.Symbol, default, default, out var leanSymbol))
         {
             Log.Error($"{nameof(TradeStationBrokerage)}.{nameof(HandleQuoteEvents)}: Failed to map symbol '{quote.Symbol}' from received quote: {quote}.");

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -328,6 +328,8 @@ public partial class TradeStationBrokerage : Brokerage
         _priceMapper = new PriceMapper();
         _messageHandler = new(HandleTradeStationMessage, ConcurrencyEnabled);
 
+        _tradeStationApiClient.Message += OnBrokerageMessageEventHandler;
+
         _aggregator = Composer.Instance.GetPart<IDataAggregator>();
         if (_aggregator == null)
         {
@@ -1544,6 +1546,10 @@ public partial class TradeStationBrokerage : Brokerage
     /// </summary>
     public override void Dispose()
     {
+        if (_tradeStationApiClient != null)
+        {
+            _tradeStationApiClient.Message -= OnBrokerageMessageEventHandler;
+        }
         _aggregator.DisposeSafely();
         _tradeStationApiClient.DisposeSafely();
     }

--- a/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
+++ b/QuantConnect.TradeStationBrokerage/TradeStationBrokerage.cs
@@ -316,19 +316,18 @@ public partial class TradeStationBrokerage : Brokerage
         {
             _tradeStationAccountType = TradeStationExtensions.ParseAccountType(accountType);
             _tradeStationApiClient = new TradeStationApiClient(clientId, clientSecret, restApiUrl,
-                _tradeStationAccountType, refreshToken, redirectUrl, authorizationCode);
+                _tradeStationAccountType, refreshToken, redirectUrl, authorizationCode, OnBrokerageMessageEventHandler);
         }
         else
         {
-            _tradeStationApiClient = new TradeStationApiClient(clientId, clientSecret, restApiUrl, refreshToken, redirectUrl, authorizationCode, accountId);
+            _tradeStationApiClient = new TradeStationApiClient(clientId, clientSecret, restApiUrl, refreshToken, redirectUrl, authorizationCode, accountId,
+                OnBrokerageMessageEventHandler);
             _tradeStationAccountType = _tradeStationApiClient.GetAccountType().SynchronouslyAwaitTaskResult();
             Log.Trace($"{nameof(TradeStationBrokerage)}.{nameof(Initialize)}: AccountID: {accountId} - AccountType: {_tradeStationAccountType}");
         }
 
         _priceMapper = new PriceMapper();
         _messageHandler = new(HandleTradeStationMessage, ConcurrencyEnabled);
-
-        _tradeStationApiClient.Message += OnBrokerageMessageEventHandler;
 
         _aggregator = Composer.Instance.GetPart<IDataAggregator>();
         if (_aggregator == null)
@@ -1546,10 +1545,6 @@ public partial class TradeStationBrokerage : Brokerage
     /// </summary>
     public override void Dispose()
     {
-        if (_tradeStationApiClient != null)
-        {
-            _tradeStationApiClient.Message -= OnBrokerageMessageEventHandler;
-        }
         _aggregator.DisposeSafely();
         _tradeStationApiClient.DisposeSafely();
     }


### PR DESCRIPTION
## Problem

TradeStation reports a per symbol market data failure without failing the request, and neither form reached the user:

- **Streaming quotes** emit a frame carrying only the symbol and an error, then go quiet for that symbol:
  ```json
  {"Symbol":"VXMQ26","Error":"FAILED, NOT ENTITLED"}
  ```
  `HandleQuoteEvents` deserialized it into a `Quote` whose symbol still resolved through the symbol mapper, so it was published as an empty quote. The algorithm received **no data at all** for that symbol, with nothing logged to explain why.

- **Bar charts** answer `HTTP 200` with an error body:
  ```json
  {"Error":"Failed","Message":"Not entitled to data for this symbol"}
  ```
  `GetBarsAsync` turned it into an exception that it caught and logged, so history quietly returned nothing.

Found while investigating why VXM (CBOE Mini VIX) futures produced no data. The symbology was correct end to end — TradeStation resolves `VXMQ26` to "Mini-VIX Futures Aug 2026", expiry `2026-08-19`, matching LEAN's computed expiry — the account simply has no CFE entitlement. Diagnosing that required going around the brokerage and querying the REST API by hand, because the plugin said nothing.

## Change

Both paths now raise a `BrokerageMessageEvent` naming the symbol the error refers to:

```
Error - Code: MarketDataError - FAILED, NOT ENTITLED for this symbol: VXMQ26
Error - Code: Failed - Not entitled to data for this symbol: VXMQ26
```

- `Quote.Error` added so the stream frame's error survives deserialization.
- `HandleQuoteEvents` reports it once per symbol, so a stream reconnection does not repeat the message.
- `TradeStationApiClient` gained a `Message` event for conditions the user should know about; the brokerage forwards it through `OnBrokerageMessageEventHandler` (previously declared but never subscribed). The bars path keeps its `Log.Error` so standalone/downloader use still reports.

## Note for review

`BrokerageMessageType.Error` is fatal in LEAN — it sets a runtime error and stops the algorithm. That seems right for a live subscription (a subscribed symbol delivering no data leaves the algorithm broken, and it matches the existing `DelayStreamingData` handling right below it), but it is a behavior change on the **history** path: an algorithm requesting history for one non-entitled symbol during warm-up will now stop rather than continue with no data. Happy to downgrade the bar charts one to `Warning` if that is preferred.

## Testing

- `DeserializeStreamQuoteErrorFrame` — the stream error frame populates `Quote.Error`/`Symbol` and no prices.
- `StreamQuoteErrorFrameRaisesBrokerageMessageOncePerSymbol` — one `BrokerageMessageType.Error` with the expected text, and a repeated frame for the same symbol does not raise a second.
- `DeserializeBarsErrorResponse` (existing) still covers the bar charts error body.
- Verified live against the TradeStation simulator: subscribing to `VXMQ26`/`VXMU26`/`VXMV26` previously sat silent for minutes; it now reports each symbol by name. `ESU26` was used as a positive control and streams normally (100 ticks in under a minute) with no messages raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)